### PR TITLE
A more complete fix for synonym items.

### DIFF
--- a/generated-items.rkt
+++ b/generated-items.rkt
@@ -1,4288 +1,6920 @@
 #lang racket
-; Generated via parse-items.rkt by danm at 2018-11-04T20:28:47 Eastern Standard Time
+; Generated via parse-items.rkt by danm at 2018-11-07T21:27:39 Eastern Standard Time
 (require "items.rkt")
 (define generated-items
-  '(#s(item$
-       Ablative-Armour
-       "UT_SHIPSHIELD"
-       1
-       (Technology:Ship TechnologyRarity:Rare TechShopRarity:Common)
-       "Ablative Armour")
-    #s(item$
-       Access-Ramp
-       "BUILDRAMP"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Access Ramp")
-    #s(item$
-       Acid
-       "FARMPROD1"
-       188000
-       (Substance:Special Rarity:Rare Product:Tradeable)
-       "Acid")
-    #s(item$ Activated-Cadmium "EX_RED" 450 (Rarity:Rare) "Activated Cadmium")
-    #s(item$
-       Activated-Copper
-       "EX_YELLOW"
-       245
-       (Rarity:Common)
-       "Activated Copper")
-    #s(item$ Activated-Emeril "EX_GREEN" 696 (Rarity:Rare) "Activated Emeril")
-    #s(item$ Activated-Indium "EX_BLUE" 949 (Rarity:Rare) "Activated Indium")
-    #s(item$
-       Advanced-Ion-Battery
-       "POWERCELL2"
-       500
-       (Substance:Catalyst Rarity:Uncommon Product:Consumable)
-       "Advanced Ion Battery")
-    #s(item$
-       Advanced-Mining-Laser
-       "STRONGLASER"
-       1
-       (Technology:Weapon TechnologyRarity:Common TechShopRarity:Common)
-       "Advanced Mining Laser")
-    #s(item$
-       Agricultural-Terminal
-       "NPCFARMTERM"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Agricultural Terminal")
-    #s(item$
-       Albumen-Pearl
-       "ALBUMENPEARL"
-       9500
-       (Substance:Exotic Rarity:Rare Product:Tradeable)
-       "Albumen Pearl")
-    #s(item$
-       Albumen-Pearl-Orb
-       "PEARLPLANT"
-       3
-       (Substance:BuildingPart Rarity:Rare Product:BuildingPart)
-       "Albumen Pearl Orb")
-    #s(item$
-       Alternator
-       "MAINT_TECH23"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Alternator")
-    #s(item$ Ammonia "TOXIC1" 62 (Rarity:Uncommon) "Ammonia")
-    #s(item$
-       Amplified-Cartridges
-       "UT_SMG"
-       1
-       (Technology:Weapon TechnologyRarity:Common TechShopRarity:Common)
-       "Amplified Cartridges")
-    #s(item$
-       Analysis-Visor
-       "SCANBINOC1"
-       1
-       (Technology:Weapon TechnologyRarity:Always TechShopRarity:Impossible)
-       "Analysis Visor")
-    #s(item$
-       Ancient-Key
-       "ARTIFACT_KEY"
-       1000
-       (Substance:Special Rarity:Rare Product:Curiousity)
-       "Ancient Key")
-    #s(item$
-       Ancient-Lock
-       "MAINT_ARTIFACT"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Ancient Lock")
-    #s(item$
-       Anomaly-Decal
-       "SPEC_DECAL01"
-       400
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Anomaly Decal")
-    #s(item$
-       Antimatter
-       "ANTIMATTER"
-       5233
-       (Substance:Special Rarity:Rare Product:Component)
-       "Antimatter")
-    #s(item$
-       Antimatter-Housing
-       "AM_HOUSING"
-       6500
-       (Substance:Special Rarity:Uncommon Product:Component)
-       "Antimatter Housing")
-    #s(item$
-       Apollo-Decal
-       "SPEC_DECAL06"
-       400
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Apollo Decal")
-    #s(item$
-       Appearance-Modifier
-       "DRESSING_TABLE"
-       10
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Appearance Modifier")
-    #s(item$
-       Aquatic-Crystal
-       "BASE_WPLANT2"
-       500
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Aquatic Crystal")
-    #s(item$
-       Armoured-Boots
-       "SPEC_VYK_BOOTS"
-       1000
-       (Substance:Exotic Rarity:Common Product:CustomisationPart)
-       "Armoured Boots")
-    #s(item$
-       Armoured-Chestpiece
-       "SPEC_VYK_TORSO"
-       750
-       (Substance:Exotic Rarity:Common Product:CustomisationPart)
-       "Armoured Chestpiece")
-    #s(item$
-       Armoured-ExoGloves
-       "SPEC_VYK_GLOVES"
-       1000
-       (Substance:Exotic Rarity:Common Product:CustomisationPart)
-       "Armoured ExoGloves")
-    #s(item$
-       Armoured-Leggings
-       "SPEC_VYK_LEGS"
-       750
-       (Substance:Exotic Rarity:Common Product:CustomisationPart)
-       "Armoured Leggings")
-    #s(item$
-       Armoured-Shoulderpads
-       "SPEC_VYK_ARMOUR"
-       3000
-       (Substance:Exotic Rarity:Common Product:CustomisationPart)
-       "Armoured Shoulderpads")
-    #s(item$
-       Aronium
-       "ALLOY1"
-       25000
-       (Substance:Stellar Rarity:Rare Product:Tradeable)
-       "Aronium")
-    #s(item$
-       Artemis-Decal
-       "SPEC_DECAL07"
-       400
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Artemis Decal")
-    #s(item$
-       Atlas-Stone
-       "ATLAS_STONE"
-       68750
-       (Substance:Special Rarity:Rare Product:Curiousity)
-       "Atlas Stone")
-    #s(item$
-       AtlasPass-v1
-       "ACCESS1"
-       825
-       (Substance:Stellar Rarity:Common Product:Curiousity)
-       "AtlasPass v1")
-    #s(item$
-       AtlasPass-v2
-       "ACCESS2"
-       1856
-       (Substance:Stellar Rarity:Uncommon Product:Curiousity)
-       "AtlasPass v2")
-    #s(item$
-       AtlasPass-v3
-       "ACCESS3"
-       2613
-       (Substance:Stellar Rarity:Rare Product:Curiousity)
-       "AtlasPass v3")
-    #s(item$
-       Atmosphere-Harvester
-       "BUILDGASHARVEST"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Atmosphere Harvester")
-    #s(item$
-       Auto-Sprinkler
-       "MAINT_FARM2"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Auto Sprinkler")
-    #s(item$
-       Auto=Propagator
-       "MAINT_FARM4"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Auto-Propagator")
-    #s(item$
-       Autonomous-Mining-Unit
-       "BUILDHARVESTER"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Autonomous Mining Unit")
-    #s(item$
-       Autonomous-Positioning-Unit
-       "TRA_TECH4"
-       30000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "Autonomous Positioning Unit")
-    #s(item$
-       BRIDGECONNECTOR
-       "BRIDGECONNECTOR"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "BRIDGECONNECTOR")
-    #s(item$
-       Barnacle
-       "BASE_BARNACLE"
-       500
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Barnacle")
-    #s(item$
-       Barrel-Fabricator
-       "CRATELCYLINDER"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Barrel Fabricator")
-    #s(item$
-       Barrel-Ioniser
-       "UT_BOLT"
-       1
-       (Technology:Weapon TechnologyRarity:Common TechShopRarity:Common)
-       "Barrel Ioniser")
-    #s(item$
-       Base-Computer
-       "BASE_FLAG"
-       5
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Base Computer")
-    #s(item$
-       Base-Salvage-Capsule
-       "BASECAPSULE"
-       10
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Base Salvage Capsule")
-    #s(item$
-       Base-Teleport-Module
-       "TELEPORTER"
-       2
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Base Teleport Module")
-    #s(item$
-       Beacon
-       "BUILDBEACON"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Beacon")
-    #s(item$
-       Bed
-       "BUILDBED"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Bed")
-    #s(item$
-       Bio=Dome
-       "BIOROOM"
-       10
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Bio-Dome")
-    #s(item$
-       Bio=input-sensor
-       "MAINT_TECH5"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Bio-input sensor")
-    #s(item$
-       Blaze-Javelin
-       "RAILGUN"
-       1
-       (Technology:Weapon TechnologyRarity:Common TechShopRarity:Common)
-       "Blaze Javelin")
-    #s(item$
-       |Blaze-Javelin-Module-(A)|
-       "U_RAIL3"
-       240
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Blaze Javelin Module (A)")
-    #s(item$
-       |Blaze-Javelin-Module-(B)|
-       "U_RAIL2"
-       140
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Blaze Javelin Module (B)")
-    #s(item$
-       |Blaze-Javelin-Module-(C)|
-       "U_RAIL1"
-       60
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Blaze Javelin Module (C)")
-    #s(item$
-       |Blaze-Javelin-Module-(S)|
-       "U_RAIL4"
-       360
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Blaze Javelin Module (S)")
-    #s(item$
-       Blazing-Orbit-Helmet
-       "SPEC_HELMET02"
-       3000
-       (Substance:Exotic Rarity:Common Product:CustomisationPart)
-       "Blazing Orbit Helmet")
-    #s(item$
-       Blown-Transistor
-       "WEAPSLOT_DMG2"
-       1
-       (Technology:Weapon
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Blown Transistor")
-    #s(item$
-       Blueprint-Analyser
-       "BP_ANALYSER"
-       10
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Blueprint Analyser")
-    #s(item$
-       Boiler-Unit
-       "MAINT_TECH6"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Boiler Unit")
-    #s(item$
-       Boltcaster
-       "BOLT"
-       1
-       (Technology:Weapon
-        TechnologyRarity:VeryCommon
-        TechShopRarity:Impossible)
-       "Boltcaster")
-    #s(item$
-       |Boltcaster-Module-(A)|
-       "U_BOLT3"
-       240
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Boltcaster Module (A)")
-    #s(item$
-       |Boltcaster-Module-(B)|
-       "U_BOLT2"
-       140
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Boltcaster Module (B)")
-    #s(item$
-       |Boltcaster-Module-(C)|
-       "U_BOLT1"
-       60
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Boltcaster Module (C)")
-    #s(item$
-       |Boltcaster-Module-(S)|
-       "U_BOLT4"
-       360
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Boltcaster Module (S)")
-    #s(item$
-       Boltcaster-SM
-       "BOLT_SM"
-       1
-       (Technology:Weapon
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Boltcaster SM")
-    #s(item$
-       Bromide-Salt
-       "TRA_MINERALS3"
-       15000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "Bromide Salt")
-    #s(item$
-       Bronze-Astronaut-Statue
-       "STATUE_ASTRO_B"
-       300
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Bronze Astronaut Statue")
-    #s(item$
-       Bronze-Atlas-Statue
-       "STATUE_ATLAS_B"
-       300
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Bronze Atlas Statue")
-    #s(item$
-       Bronze-Blob-Statue
-       "STATUE_BLOB_B"
-       300
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Bronze Blob Statue")
-    #s(item$
-       Bronze-Diplo-Statue
-       "STATUE_DIP_B"
-       300
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Bronze Diplo Statue")
-    #s(item$
-       Bronze-Fighter-Statue
-       "STATUE_SHIP_B"
-       300
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Bronze Fighter Statue")
-    #s(item$
-       Bronze-Gek-Statue
-       "STATUE_GEK_B"
-       300
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Bronze Gek Statue")
-    #s(item$
-       Bronze-Walker-Statue
-       "STATUE_WALK_B"
-       300
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Bronze Walker Statue")
-    #s(item$
-       CORRIDOR_WINDOW
-       "CORRIDOR_WINDOW"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "CORRIDOR_WINDOW")
-    #s(item$ Cactus-Flesh "PLANT_DUST" 28 (Rarity:Rare) "Cactus Flesh")
-    #s(item$ Cadmium "RED2" 234 (Rarity:Rare) "Cadmium")
-    #s(item$
-       Cadmium-Drive
-       "HDRIVEBOOST1"
-       1
-       (Technology:Ship TechnologyRarity:VeryRare TechShopRarity:Common)
-       "Cadmium Drive")
-    #s(item$
-       Candelabra-Bloom
-       "BASE_WPLANT3"
-       500
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Candelabra Bloom")
-    #s(item$
-       Canister-Rack
-       "BUILDCANRACK"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Canister Rack")
-    #s(item$
-       Captured-Nanode
-       "ATLAS_SEED_1"
-       1000
-       (Substance:Stellar Rarity:Rare Product:Curiousity)
-       "Captured Nanode")
-    #s(item$ Carbon "FUEL1" 12 (Rarity:Common) "Carbon")
-    #s(item$
-       Carbon-Crystal
-       "FUELPROD3"
-       3600
-       (Substance:Exotic Rarity:Rare Product:Curiousity)
-       "Carbon Crystal")
-    #s(item$
-       Carbon-Nanotubes
-       "NANOTUBES"
-       500
-       (Substance:Catalyst Rarity:Common Product:Component)
-       "Carbon Nanotubes")
-    #s(item$
-       Carnivorous-Bush
-       "BASE_MEDPLANT01"
-       500
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Carnivorous Bush")
-    #s(item$
-       Ceiling-Light
-       "CEILINGLIGHT"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Ceiling Light")
-    #s(item$
-       Ceiling-Panel
-       "ROOFMONITOR"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Ceiling Panel")
-    #s(item$
-       Celebrate!
-       "SPEC_EMOTE02"
-       1500
-       (Substance:Exotic Rarity:Common Product:Emote)
-       "Celebrate!")
-    #s(item$
-       Chair
-       "BUILDCHAIR"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Chair")
-    #s(item$
-       Chloride-Lattice
-       "WATERPROD3"
-       6150
-       (Substance:Exotic Rarity:Rare Product:Curiousity)
-       "Chloride Lattice")
-    #s(item$ Chlorine "WATER2" 602 (Rarity:Rare) "Chlorine")
-    #s(item$ Chromatic-Metal "STELLAR2" 245 (Rarity:Rare) "Chromatic Metal")
-    #s(item$
-       Circuit-Board
-       "FARMPROD9"
-       916250
-       (Substance:Special Rarity:Rare Product:Tradeable)
-       "Circuit Board")
-    #s(item$ Cobalt "CAVE1" 198 (Rarity:Common) "Cobalt")
-    #s(item$
-       Cobalt-Mirror
-       "CAVE_CRAFT"
-       20500
-       (Substance:Stellar Rarity:Uncommon Product:Component)
-       "Cobalt Mirror")
-    #s(item$
-       Colossus-Geobay
-       "GARAGE_L"
-       10
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Colossus Geobay")
-    #s(item$
-       Coloured-Light
-       "WALLLIGHTBLUE"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Coloured Light")
-    #s(item$
-       Combat-Scope
-       "SCOPE"
-       1
-       (Technology:Weapon TechnologyRarity:Common TechShopRarity:Common)
-       "Combat Scope")
-    #s(item$
-       Communications-Station
-       "MESSAGE"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Communications Station")
-    #s(item$
-       Concrete-Arch
-       "C_ARCH"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Concrete Arch")
-    #s(item$
-       Concrete-Door-Frame
-       "C_DOOR"
-       2
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Concrete Door Frame")
-    #s(item$
-       Concrete-Doorway
-       "C_DOOR_H"
-       2
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Concrete Doorway")
-    #s(item$
-       Concrete-Floor-Panel
-       "C_FLOOR"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Concrete Floor Panel")
-    #s(item$
-       Concrete-Frontage
-       "C_DOORWINDOW"
-       3
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Concrete Frontage")
-    #s(item$
-       Concrete-Half-Arch
-       "C_ARCH_H"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Concrete Half Arch")
-    #s(item$
-       Concrete-Half-Ramp
-       "C_RAMP_H"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Concrete Half Ramp")
-    #s(item$
-       Concrete-Ramp
-       "C_RAMP"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Concrete Ramp")
-    #s(item$
-       Concrete-Roof
-       "C_ROOF"
-       2
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Concrete Roof")
-    #s(item$
-       Concrete-Roof-Corner
-       "C_ROOF_C"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Concrete Roof Corner")
-    #s(item$
-       Concrete-Roof-Panel
-       "C_ROOF_M"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Concrete Roof Panel")
-    #s(item$
-       Concrete-Wall
-       "C_WALL"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Concrete Wall")
-    #s(item$
-       Concrete-Window-Panel
-       "C_WALL_WINDOW"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Concrete Window Panel")
-    #s(item$
-       Concrete=Framed-Glass-Panel
-       "C_GFLOOR"
-       3
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Concrete-Framed Glass Panel")
-    #s(item$ Condensed-Carbon "FUEL2" 24 (Rarity:Uncommon) "Condensed Carbon")
-    #s(item$
-       Conflict-Scanner
-       "SHIPSCAN_COMBAT"
-       1
-       (Technology:Ship TechnologyRarity:Normal TechShopRarity:Common)
-       "Conflict Scanner")
-    #s(item$
-       Construction-Terminal
-       "NPCBUILDERTERM"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Construction Terminal")
-    #s(item$
-       Containment-Failure
-       "SHIPSLOT_DMG5"
-       1
-       (Technology:Ship TechnologyRarity:Impossible TechShopRarity:Impossible)
-       "Containment Failure")
-    #s(item$
-       Cooling-system
-       "MAINT_TECH8"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Cooling system")
-    #s(item$ Copper "YELLOW2" 121 (Rarity:Common) "Copper")
-    #s(item$ Coprite "PLANT_POOP" 30 (Rarity:Common) "Coprite")
-    #s(item$
-       Coprite-Flower
-       "POOPPLANT"
-       3
-       (Substance:BuildingPart Rarity:Rare Product:BuildingPart)
-       "Coprite Flower")
-    #s(item$
-       Corner-Sofa
-       "BUILDSOFA2L"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Corner Sofa")
-    #s(item$
-       Corrupt-Module
-       "WEAPSLOT_DMG5"
-       1
-       (Technology:Weapon
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Corrupt Module")
-    #s(item$
-       Crate-Fabricator
-       "CRATELRARE"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Crate Fabricator")
-    #s(item$
-       Creature-Hologram
-       "CREATHOLOGRAM"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Creature Hologram")
-    #s(item$
-       Cryo=Pump
-       "COMPOUND6"
-       1500000
-       (Substance:Special Rarity:Rare Product:Tradeable)
-       "Cryo-Pump")
-    #s(item$
-       Cryogenic-Chamber
-       "MEGAPROD3"
-       3800000
-       (Substance:Special Rarity:Rare Product:Tradeable)
-       "Cryogenic Chamber")
-    #s(item$
-       Crystal-Sulphide
-       "VENTGEM"
-       7800
-       (Substance:Exotic Rarity:Rare Product:Tradeable)
-       "Crystal Sulphide")
-    #s(item$
-       Cube
-       "CUBESHAPE"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Cube")
-    #s(item$
-       Cuboid-Inner-Door
-       "CUBEINNERDOOR"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Cuboid Inner Door")
-    #s(item$
-       Cuboid-Inner-Wall
-       "CUBEWALL"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Cuboid Inner Wall")
-    #s(item$
-       Cuboid-Roof-Cap
-       "CUBEROOF"
-       2
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Cuboid Roof Cap")
-    #s(item$
-       Cuboid-Room
-       "CUBEROOM"
-       2
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Cuboid Room")
-    #s(item$
-       Cuboid-Room-Flooring
-       "CUBEFLOOR"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Cuboid Room Flooring")
-    #s(item$
-       Cuboid-Room-Foundation-Strut
-       "CUBEFOUND"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Cuboid Room Foundation Strut")
-    #s(item$
-       Cuboid-Room-Foundation-Strut-Quad
-       "CUBEFOUND4"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Cuboid Room Foundation Strut Quad")
-    #s(item$
-       Cuboid-Room-Frame
-       "CUBEFRAME"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Cuboid Room Frame")
-    #s(item$
-       Cuboid-Room-Ladder
-       "CUBELADDER"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Cuboid Room Ladder")
-    #s(item$
-       Curious-Corn
-       "BASE_MEDPLANT03"
-       500
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Curious Corn")
-    #s(item$
-       Curly-Coral
-       "BASE_WPLANT1"
-       500
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Curly Coral")
-    #s(item$
-       Curved-Corridor
-       "CORRIDORC"
-       3
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Curved Corridor")
-    #s(item$
-       Curved-Cuboid-Roof
-       "CURVEDCUBEROOF"
-       3
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Curved Cuboid Roof")
-    #s(item$
-       Curved-Cuboid-Wall
-       "CUBEROOMCURVED"
-       3
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Curved Cuboid Wall")
-    #s(item$
-       Curved-Desk
-       "CURVEDDESK"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Curved Desk")
-    #s(item$
-       Curved-Freighter-Corridor
-       "CORRIDORL_SPACE"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Curved Freighter Corridor")
-    #s(item$
-       Curved-Pipe
-       "CURVEPIPESHAPE"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Curved Pipe")
-    #s(item$
-       Curved-Wall
-       "WALLCURVED"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Curved Wall")
-    #s(item$
-       Cyclotron-Ballista
-       "SHIPPLASMA"
-       1
-       (Technology:Ship TechnologyRarity:Impossible TechShopRarity:Normal)
-       "Cyclotron Ballista")
-    #s(item$
-       |Cyclotron-Module-(A)|
-       "U_SHIPBLOB3"
-       240
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Cyclotron Module (A)")
-    #s(item$
-       |Cyclotron-Module-(B)|
-       "U_SHIPBLOB2"
-       140
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Cyclotron Module (B)")
-    #s(item$
-       |Cyclotron-Module-(C)|
-       "U_SHIPBLOB1"
-       60
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Cyclotron Module (C)")
-    #s(item$
-       |Cyclotron-Module-(S)|
-       "U_SHIPBLOB4"
-       360
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Cyclotron Module (S)")
-    #s(item$
-       Cylinder
-       "CYLINDERSHAPE"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Cylinder")
-    #s(item$
-       Cylindrical-Room
-       "MAINROOM"
-       3
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Cylindrical Room")
-    #s(item$
-       Cylindrical-Room-Frame
-       "MAINROOMFRAME"
-       3
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Cylindrical Room Frame")
-    #s(item$ Cyto=Phosphate "WATERPLANT" 201 (Rarity:Rare) "Cyto-Phosphate")
-    #s(item$
-       Damaged-Electrode
-       "EXOPOD_TECH2"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Damaged Electrode")
-    #s(item$
-       Damaged-Gears
-       "SHIPSLOT_DMG6"
-       1
-       (Technology:Ship TechnologyRarity:Impossible TechShopRarity:Impossible)
-       "Damaged Gears")
-    #s(item$
-       Damaged-Wiring
-       "WEAPSLOT_DMG3"
-       1
-       (Technology:Weapon
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Damaged Wiring")
-    #s(item$
-       Dark-Matter
-       "ATLAS_SEED_4"
-       1000
-       (Substance:Stellar Rarity:Rare Product:Curiousity)
-       "Dark Matter")
-    #s(item$
-       |Dawn's-End|
-       "ATLAS_SEED_5"
-       1000
-       (Substance:Stellar Rarity:Rare Product:Curiousity)
-       "Dawn's End")
-    #s(item$
-       De=Scented-Pheromone-Bottle
-       "TRA_EXOTICS1"
-       1000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "De-Scented Pheromone Bottle")
-    #s(item$
-       Decal
-       "BUILDDECAL"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Decal")
-    #s(item$
-       Decommissioned-Circuit-Board
-       "TRA_TECH1"
-       1000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "Decommissioned Circuit Board")
-    #s(item$
-       Deepwater-Chamber
-       "MAINROOM_WATER"
-       6
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Deepwater Chamber")
-    #s(item$
-       Defence-Chit
-       "POLICE_TOKEN"
-       10000
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Defence Chit")
-    #s(item$
-       Deflector-Shield
-       "SHIPSHIELD"
-       1
-       (Technology:Ship TechnologyRarity:Always TechShopRarity:Impossible)
-       "Deflector Shield")
-    #s(item$
-       Destablised-Sodium
-       "CATAPROD3"
-       12300
-       (Substance:Exotic Rarity:Rare Product:Curiousity)
-       "Destablised Sodium")
-    #s(item$ Deuterium "LAUNCHSUB2" 34 (Rarity:Common) "Deuterium")
-    #s(item$ Di=hydrogen "LAUNCHSUB" 34 (Rarity:Common) "Di-hydrogen")
-    #s(item$
-       Di=hydrogen-Jelly
-       "JELLY"
-       200
-       (Substance:Fuel Rarity:Common Product:Component)
-       "Di-hydrogen Jelly")
-    #s(item$ Dioxite "COLD1" 62 (Rarity:Uncommon) "Dioxite")
-    #s(item$
-       Dirt
-       "TRA_MINERALS1"
-       1000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "Dirt")
-    #s(item$
-       Dirty-Bronze
-       "ALLOY2"
-       25000
-       (Substance:Stellar Rarity:Rare Product:Tradeable)
-       "Dirty Bronze")
-    #s(item$
-       Door
-       "BUILDDOOR"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Door")
-    #s(item$
-       Drawers
-       "DRAWS"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Drawers")
-    #s(item$
-       Drift-Suspension
-       "VEHICLE_GRIP1"
-       1
-       (Technology:Exocraft
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Drift Suspension")
-    #s(item$
-       Drop-Pod-Coordinate-Data
-       "NAV_DATA_DROP"
-       85000
-       (Substance:Special Rarity:Rare Product:Curiousity)
-       "Drop Pod Coordinate Data")
-    #s(item$
-       Dwarf-Palm
-       "BASE_MEDPLANT02"
-       500
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Dwarf Palm")
-    #s(item$
-       Dyson-Pump
-       "UT_SHIPBLOB"
-       1
-       (Technology:Ship TechnologyRarity:Impossible TechShopRarity:Common)
-       "Dyson Pump")
-    #s(item$
-       Echinocactus
-       "BARRENPLANT"
-       3
-       (Substance:BuildingPart Rarity:Rare Product:BuildingPart)
-       "Echinocactus")
-    #s(item$
-       Economy-Scanner
-       "SHIPSCAN_ECON"
-       1
-       (Technology:Ship TechnologyRarity:Normal TechShopRarity:Common)
-       "Economy Scanner")
-    #s(item$
-       Efficient-Thrusters
-       "UT_LAUNCHER"
-       1
-       (Technology:Ship TechnologyRarity:Normal TechShopRarity:Common)
-       "Efficient Thrusters")
-    #s(item$
-       Efficient-Water-Jets
-       "UT_WATERJET"
-       1
-       (Technology:Suit TechnologyRarity:Common TechShopRarity:Common)
-       "Efficient Water Jets")
-    #s(item$ Emeril "GREEN2" 348 (Rarity:Rare) "Emeril")
-    #s(item$
-       Emeril-Drive
-       "HDRIVEBOOST2"
-       1
-       (Technology:Ship TechnologyRarity:VeryRare TechShopRarity:Common)
-       "Emeril Drive")
-    #s(item$
-       Englobed-Shade
-       "ATLAS_SEED_2"
-       1000
-       (Substance:Stellar Rarity:Rare Product:Curiousity)
-       "Englobed Shade")
-    #s(item$
-       Enriched-Carbon
-       "REACTION2"
-       50000
-       (Substance:Special Rarity:Rare Product:Tradeable)
-       "Enriched Carbon")
-    #s(item$
-       Evergreen-Tree
-       "BASE_TREE03"
-       500
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Evergreen Tree")
-    #s(item$
-       Exocraft-Acceleration-Module
-       "VEHICLE_BOOST"
-       1
-       (Technology:Exocraft
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Exocraft Acceleration Module")
-    #s(item$
-       |Exocraft-Boost-Module-(A)|
-       "U_EXOBOOST3"
-       240
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Exocraft Boost Module (A)")
-    #s(item$
-       |Exocraft-Boost-Module-(B)|
-       "U_EXOBOOST2"
-       140
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Exocraft Boost Module (B)")
-    #s(item$
-       |Exocraft-Boost-Module-(C)|
-       "U_EXOBOOST1"
-       60
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Exocraft Boost Module (C)")
-    #s(item$
-       |Exocraft-Boost-Module-(S)|
-       "U_EXOBOOST4"
-       360
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Exocraft Boost Module (S)")
-    #s(item$
-       |Exocraft-Cannon-Module-(A)|
-       "U_EXOGUN3"
-       240
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Exocraft Cannon Module (A)")
-    #s(item$
-       |Exocraft-Cannon-Module-(B)|
-       "U_EXOGUN2"
-       140
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Exocraft Cannon Module (B)")
-    #s(item$
-       |Exocraft-Cannon-Module-(C)|
-       "U_EXOGUN1"
-       60
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Exocraft Cannon Module (C)")
-    #s(item$
-       |Exocraft-Cannon-Module-(S)|
-       "U_EXOGUN4"
-       360
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Exocraft Cannon Module (S)")
-    #s(item$
-       |Exocraft-Engine-Module-(A)|
-       "U_EXO_ENG3"
-       240
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Exocraft Engine Module (A)")
-    #s(item$
-       |Exocraft-Engine-Module-(B)|
-       "U_EXO_ENG2"
-       140
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Exocraft Engine Module (B)")
-    #s(item$
-       |Exocraft-Engine-Module-(C)|
-       "U_EXO_ENG1"
-       60
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Exocraft Engine Module (C)")
-    #s(item$
-       |Exocraft-Engine-Module-(S)|
-       "U_EXO_ENG4"
-       360
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Exocraft Engine Module (S)")
-    #s(item$
-       |Exocraft-Laser-Module-(A)|
-       "U_EXOLAS3"
-       240
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Exocraft Laser Module (A)")
-    #s(item$
-       |Exocraft-Laser-Module-(B)|
-       "U_EXOLAS2"
-       140
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Exocraft Laser Module (B)")
-    #s(item$
-       |Exocraft-Laser-Module-(C)|
-       "U_EXOLAS1"
-       60
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Exocraft Laser Module (C)")
-    #s(item$
-       |Exocraft-Laser-Module-(S)|
-       "U_EXOLAS4"
-       360
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Exocraft Laser Module (S)")
-    #s(item$
-       Exocraft-Mining-Laser
-       "VEHICLE_LASER"
-       1
-       (Technology:Exocraft
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Exocraft Mining Laser")
-    #s(item$
-       Exocraft-Mining-Laser-Upgrade-Sigma
-       "VEHICLE_LASER1"
-       1
-       (Technology:Exocraft
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Exocraft Mining Laser Upgrade Sigma")
-    #s(item$
-       Exocraft-Mounted-Cannon
-       "VEHICLE_GUN"
-       1
-       (Technology:Exocraft
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Exocraft Mounted Cannon")
-    #s(item$
-       Exocraft-Signal-Booster
-       "VEHICLE_SCAN"
-       1
-       (Technology:Exocraft
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Exocraft Signal Booster")
-    #s(item$
-       Exocraft-Signal-Booster-Upgrade-Sigma
-       "VEHICLE_SCAN1"
-       1
-       (Technology:Exocraft
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Exocraft Signal Booster Upgrade Sigma")
-    #s(item$
-       Exocraft-Signal-Booster-Upgrade-Tau
-       "VEHICLE_SCAN2"
-       1
-       (Technology:Exocraft
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Exocraft Signal Booster Upgrade Tau")
-    #s(item$
-       Exocraft-Summoning-Station
-       "SUMMON_GARAGE"
-       10
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Exocraft Summoning Station")
-    #s(item$
-       Exocraft-Terminal
-       "NPCVEHICLETERM"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Exocraft Terminal")
-    #s(item$
-       Expanding-Cube-Gadget
-       "BASE_TOYCUBE"
-       800
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Expanding Cube Gadget")
-    #s(item$
-       Experimental-Power-Fluid
-       "TRA_ENERGY4"
-       30000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "Experimental Power Fluid")
-    #s(item$
-       Explosive-Drones
-       "FRIG_BOOST_COM"
-       75000
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Explosive Drones")
-    #s(item$
-       Faulty-Hologram
-       "EXOPOD_TECH1"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Faulty Hologram")
-    #s(item$ Ferrite-Dust "LAND1" 14 (Rarity:Common) "Ferrite Dust")
-    #s(item$
-       Five-Dimensional-Torus
-       "TRA_ALLOY4"
-       30000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "Five Dimensional Torus")
-    #s(item$
-       Flag
-       "FLAG1"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Flag")
-    #s(item$
-       Flat-Panel
-       "BUILDFLATPANEL"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Flat Panel")
-    #s(item$
-       Fleet-Command-Room
-       "NPCFRIGTERM"
-       10
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Fleet Command Room")
-    #s(item$
-       Floor-Mat
-       "FLOORMAT1"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Floor Mat")
-    #s(item$
-       Flora-Containment
-       "PLANTPOT1"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Flora Containment")
-    #s(item$
-       Foundation
-       "FOUNDATION"
-       3
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Foundation")
-    #s(item$
-       Foundation-Strut
-       "FOUNDLEG"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Foundation Strut")
-    #s(item$
-       Foundation-Strut-Quad
-       "FOUNDLEG4"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Foundation Strut Quad")
-    #s(item$
-       Fourier-De=Limiter
-       "UT_SHIPLAS"
-       1
-       (Technology:Ship TechnologyRarity:Normal TechShopRarity:Common)
-       "Fourier De-Limiter")
-    #s(item$
-       Fragment-Supercharger
-       "UT_SHIPSHOT"
-       1
-       (Technology:Ship TechnologyRarity:Impossible TechShopRarity:Common)
-       "Fragment Supercharger")
-    #s(item$
-       Freighter-Corridor
-       "CORRIDOR_SPACE"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Freighter Corridor")
-    #s(item$
-       Freighter-Cross-Junction
-       "CORRIDORX_SPACE"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Freighter Cross Junction")
-    #s(item$
-       Freighter-Hyperdrive
-       "F_HYPERDRIVE"
-       1
-       (Technology:Freighter TechnologyRarity:Always TechShopRarity:Impossible)
-       "Freighter Hyperdrive")
-    #s(item$
-       Freighter-Junction
-       "CORRIDORT_SPACE"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Freighter Junction")
-    #s(item$
-       Freighter-Stairs
-       "CORSTAIRS_SPACE"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Freighter Stairs")
-    #s(item$
-       Freighter-Storage-Unit
-       "S_CONTAINER0"
-       5
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Freighter Storage Unit")
-    #s(item$
-       Freighter-Warp-Reactor-Sigma
-       "F_HDRIVEBOOST1"
-       1
-       (Technology:Freighter TechnologyRarity:Impossible TechShopRarity:Normal)
-       "Freighter Warp Reactor Sigma")
-    #s(item$
-       Freighter-Warp-Reactor-Tau
-       "F_HDRIVEBOOST2"
-       1
-       (Technology:Freighter TechnologyRarity:Impossible TechShopRarity:Rare)
-       "Freighter Warp Reactor Tau")
-    #s(item$
-       Freighter-Warp-Reactor-Theta
-       "F_HDRIVEBOOST3"
-       1
-       (Technology:Freighter TechnologyRarity:Impossible TechShopRarity:Rare)
-       "Freighter Warp Reactor Theta")
-    #s(item$
-       |Frigate-Fuel-(100-Tonnes)|
-       "FRIGATE_FUEL_2"
-       40000
-       (Substance:Fuel Rarity:Rare Product:Consumable)
-       "Frigate Fuel (100 Tonnes)")
-    #s(item$
-       |Frigate-Fuel-(200-Tonnes)|
-       "FRIGATE_FUEL_3"
-       80000
-       (Substance:Fuel Rarity:Rare Product:Consumable)
-       "Frigate Fuel (200 Tonnes)")
-    #s(item$
-       |Frigate-Fuel-(50-Tonnes)|
-       "FRIGATE_FUEL_1"
-       20000
-       (Substance:Fuel Rarity:Rare Product:Consumable)
-       "Frigate Fuel (50 Tonnes)")
-    #s(item$ Frost-Crystal "PLANT_SNOW" 12 (Rarity:Rare) "Frost Crystal")
-    #s(item$
-       Frostwort
-       "SNOWPLANT"
-       3
-       (Substance:BuildingPart Rarity:Rare Product:BuildingPart)
-       "Frostwort")
-    #s(item$
-       Fruit-Tree
-       "BASE_TREE01"
-       500
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Fruit Tree")
-    #s(item$
-       Fuel-Inverter
-       "MAINT_FUEL1"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Fuel Inverter")
-    #s(item$
-       Fuel-Oxidiser
-       "FRIG_BOOST_SPD"
-       75000
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Fuel Oxidiser")
-    #s(item$
-       Fuel-Pump
-       "MAINT_TECH14"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Fuel Pump")
-    #s(item$
-       Fungal-Cluster
-       "TOXICPLANT"
-       3
-       (Substance:BuildingPart Rarity:Rare Product:BuildingPart)
-       "Fungal Cluster")
-    #s(item$ Fungal-Mould "PLANT_TOXIC" 16 (Rarity:Rare) "Fungal Mould")
-    #s(item$
-       Fusion-Accelerant
-       "COMPOUND4"
-       1500000
-       (Substance:Special Rarity:Rare Product:Tradeable)
-       "Fusion Accelerant")
-    #s(item$
-       Fusion-Core
-       "TRA_ENERGY5"
-       50000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "Fusion Core")
-    #s(item$
-       Fusion-Engine
-       "VEHICLE_ENGINE"
-       1
-       (Technology:Exocraft TechnologyRarity:Always TechShopRarity:Impossible)
-       "Fusion Engine")
-    #s(item$
-       Fusion-Ignitor
-       "ULTRAPROD1"
-       15600000
-       (Substance:Special Rarity:Rare Product:Tradeable)
-       "Fusion Ignitor")
-    #s(item$
-       Galactic-Hub-Decal
-       "SPEC_DECAL02"
-       400
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Galactic Hub Decal")
-    #s(item$
-       Galactic-Trade-Terminal
-       "BUILDTERMINAL"
-       10
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Galactic Trade Terminal")
-    #s(item$ Gamma-Root "PLANT_RADIO" 16 (Rarity:Rare) "Gamma Root")
-    #s(item$
-       Gamma-Weed
-       "RADIOPLANT"
-       3
-       (Substance:BuildingPart Rarity:Rare Product:BuildingPart)
-       "Gamma Weed")
-    #s(item$
-       Gek-Relic
-       "TRA_CURIO1"
-       23375
-       (Substance:Exotic Rarity:Rare Product:Curiousity)
-       "Gek Relic")
-    #s(item$
-       GekNip
-       "TRA_CURIO2"
-       20625
-       (Substance:Exotic Rarity:Uncommon Product:Curiousity)
-       "GekNip")
-    #s(item$
-       Generator-Coupling
-       "MAINT_FUEL4"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Generator Coupling")
-    #s(item$
-       Geodesite
-       "ALLOY7"
-       150000
-       (Substance:Stellar Rarity:Rare Product:Tradeable)
-       "Geodesite")
-    #s(item$
-       Geology-Cannon
-       "TERRAIN_GREN"
-       1
-       (Technology:Weapon TechnologyRarity:Common TechShopRarity:Common)
-       "Geology Cannon")
-    #s(item$
-       |Geology-Cannon-Module-(A)|
-       "U_TGRENADE3"
-       240
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Geology Cannon Module (A)")
-    #s(item$
-       |Geology-Cannon-Module-(B)|
-       "U_TGRENADE2"
-       140
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Geology Cannon Module (B)")
-    #s(item$
-       |Geology-Cannon-Module-(C)|
-       "U_TGRENADE1"
-       60
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Geology Cannon Module (C)")
-    #s(item$
-       |Geology-Cannon-Module-(S)|
-       "U_TGRENADE4"
-       360
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Geology Cannon Module (S)")
-    #s(item$
-       Glass
-       "FARMPROD3"
-       13000
-       (Substance:Special Rarity:Rare Product:Tradeable)
-       "Glass")
-    #s(item$
-       Glass-Cuboid-Room
-       "CUBEGLASS"
-       5
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Glass Cuboid Room")
-    #s(item$
-       Glass-Roofed-Corridor
-       "GLASSCORRIDOR"
-       5
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Glass Roofed Corridor")
-    #s(item$
-       Glass-Tunnel
-       "CORRIDOR_WATER"
-       3
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Glass Tunnel")
-    #s(item$ Gold "ASTEROID2" 202 (Rarity:Uncommon) "Gold")
-    #s(item$
-       Gold-Astronaut-Statue
-       "STATUE_ASTRO_G"
-       500
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Gold Astronaut Statue")
-    #s(item$
-       Gold-Atlas-Statue
-       "STATUE_ATLAS_G"
-       500
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Gold Atlas Statue")
-    #s(item$
-       Gold-Blob-Statue
-       "STATUE_BLOB_G"
-       500
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Gold Blob Statue")
-    #s(item$
-       Gold-Diplo-Statue
-       "STATUE_DIP_G"
-       500
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Gold Diplo Statue")
-    #s(item$
-       Gold-Fighter-Statue
-       "STATUE_SHIP_G"
-       500
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Gold Fighter Statue")
-    #s(item$
-       Gold-Gek-Statue
-       "STATUE_GEK_G"
-       500
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Gold Gek Statue")
-    #s(item$
-       Gold-Walker-Statue
-       "STATUE_WALK_G"
-       500
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Gold Walker Statue")
-    #s(item$
-       Grantine
-       "ALLOY6"
-       25000
-       (Substance:Stellar Rarity:Rare Product:Tradeable)
-       "Grantine")
-    #s(item$
-       Gravitino-Ball
-       "GRAVBALL"
-       13100
-       (Substance:Exotic Rarity:Rare Product:Tradeable)
-       "Gravitino Ball")
-    #s(item$
-       Gravitino-Host
-       "GRAVPLANT"
-       3
-       (Substance:BuildingPart Rarity:Rare Product:BuildingPart)
-       "Gravitino Host")
-    #s(item$
-       Green-Wall-Screen
-       "WALLSCREENB"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Green Wall Screen")
-    #s(item$
-       Grip-Boost-Suspension
-       "VEHICLE_GRIP2"
-       1
-       (Technology:Exocraft
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Grip Boost Suspension")
-    #s(item$
-       HEALTHPLANT
-       "HEALTHPLANT"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "HEALTHPLANT")
-    #s(item$
-       Ha!
-       "SPEC_EMOTE03"
-       1500
-       (Substance:Exotic Rarity:Common Product:Emote)
-       "Ha!")
-    #s(item$
-       Hadal-Core
-       "FISHCORE"
-       97500
-       (Substance:Exotic Rarity:Rare Product:Tradeable)
-       "Hadal Core")
-    #s(item$
-       Hand-of-Approval-Decal
-       "SPEC_DECAL03"
-       400
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Hand of Approval Decal")
-    #s(item$
-       Haz=Mat-Gauntlet
-       "POWERGLOVE"
-       1
-       (Technology:Suit TechnologyRarity:Common TechShopRarity:Common)
-       "Haz-Mat Gauntlet")
-    #s(item$
-       Hazard-Protection
-       "PROTECT"
-       1
-       (Technology:Suit TechnologyRarity:Always TechShopRarity:Impossible)
-       "Hazard Protection")
-    #s(item$
-       Hazard-Protection-Unit
-       "SHIELDSTATION"
-       3
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Hazard Protection Unit")
-    #s(item$
-       Health-Station
-       "HEALTHSTATION"
-       5
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Health Station")
-    #s(item$
-       Heart-of-the-Sun
-       "ATLAS_SEED_10"
-       1000
-       (Substance:Stellar Rarity:Rare Product:Curiousity)
-       "Heart of the Sun")
-    #s(item$
-       Heat-Capacitor
-       "FARMPROD4"
-       180000
-       (Substance:Special Rarity:Rare Product:Tradeable)
-       "Heat Capacitor")
-    #s(item$
-       Hermetic-Seal
-       "CARBON_SEAL"
-       800
-       (Substance:Catalyst Rarity:Uncommon Product:Component)
-       "Hermetic Seal")
-    #s(item$
-       Herox
-       "ALLOY3"
-       25000
-       (Substance:Stellar Rarity:Rare Product:Tradeable)
-       "Herox")
-    #s(item$
-       Hex-Core
-       "HEXCORE"
-       16
-       (Substance:Special Rarity:Rare Product:Curiousity)
-       "Hex Core")
-    #s(item$ Hexite "SPECIAL_POOP" 654 (Rarity:Common) "Hexite")
-    #s(item$
-       Hi=Slide-Suspension
-       "VEHICLE_GRIP3"
-       1
-       (Technology:Exocraft
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Hi-Slide Suspension")
-    #s(item$
-       High=Power-Sonar
-       "SUB_BINOCS"
-       1
-       (Technology:Submarine
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "High-Power Sonar")
-    #s(item$
-       Holo=Door
-       "DOOR2"
-       8
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Holo-Door")
-    #s(item$
-       Holographic-Analyser
-       "FRIG_BOOST_EXP"
-       75000
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Holographic Analyser")
-    #s(item$
-       Holographic-Globe-Gadget
-       "BASE_TOYSPHERE"
-       800
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Holographic Globe Gadget")
-    #s(item$
-       Hot-Ice
-       "COMPOUND3"
-       320000
-       (Substance:Special Rarity:Rare Product:Tradeable)
-       "Hot Ice")
-    #s(item$
-       Hull-Fracture
-       "SHIPSLOT_DMG1"
-       1
-       (Technology:Ship TechnologyRarity:Impossible TechShopRarity:Impossible)
-       "Hull Fracture")
-    #s(item$
-       Humboldt-Drive
-       "SUB_ENGINE"
-       1
-       (Technology:Submarine TechnologyRarity:Always TechShopRarity:Impossible)
-       "Humboldt Drive")
-    #s(item$
-       |Humboldt-Drive-Module-(A)|
-       "U_EXO_SUB3"
-       240
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Humboldt Drive Module (A)")
-    #s(item$
-       |Humboldt-Drive-Module-(B)|
-       "U_EXO_SUB2"
-       140
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Humboldt Drive Module (B)")
-    #s(item$
-       |Humboldt-Drive-Module-(C)|
-       "U_EXO_SUB1"
-       60
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Humboldt Drive Module (C)")
-    #s(item$
-       |Humboldt-Drive-Module-(S)|
-       "U_EXO_SUB4"
-       360
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Humboldt Drive Module (S)")
-    #s(item$
-       Hydroponic-Tray
-       "PLANTER"
-       3
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Hydroponic Tray")
-    #s(item$
-       Hydrothermal-Fuel-Cell
-       "SUBFUEL"
-       7200
-       (Substance:Fuel Rarity:Uncommon Product:Consumable)
-       "Hydrothermal Fuel Cell")
-    #s(item$
-       Hyperdrive
-       "HYPERDRIVE"
-       1
-       (Technology:Ship TechnologyRarity:Always TechShopRarity:Impossible)
-       "Hyperdrive")
-    #s(item$
-       |Hyperdrive-Module-(A)|
-       "U_HYPER3"
-       240
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Hyperdrive Module (A)")
-    #s(item$
-       |Hyperdrive-Module-(B)|
-       "U_HYPER2"
-       140
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Hyperdrive Module (B)")
-    #s(item$
-       |Hyperdrive-Module-(C)|
-       "U_HYPER1"
-       60
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Hyperdrive Module (C)")
-    #s(item$
-       |Hyperdrive-Module-(S)|
-       "U_HYPER4"
-       360
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Hyperdrive Module (S)")
-    #s(item$
-       Hypnotic-Eye
-       "EYEBALL"
-       60000
-       (Substance:Exotic Rarity:Rare Product:Tradeable)
-       "Hypnotic Eye")
-    #s(item$ Indium "BLUE2" 464 (Rarity:Rare) "Indium")
-    #s(item$
-       Indium-Drive
-       "HDRIVEBOOST3"
-       1
-       (Technology:Ship TechnologyRarity:Impossible TechShopRarity:Common)
-       "Indium Drive")
-    #s(item$
-       Industrial=Grade-Battery
-       "TRA_ENERGY2"
-       6000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "Industrial-Grade Battery")
-    #s(item$
-       Infra=Knife-Accelerator
-       "SHIPMINIGUN"
-       1
-       (Technology:Ship TechnologyRarity:Impossible TechShopRarity:Normal)
-       "Infra-Knife Accelerator")
-    #s(item$
-       |Infra=Knife-Module-(A)|
-       "U_SHIPMINI3"
-       240
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Infra-Knife Module (A)")
-    #s(item$
-       |Infra=Knife-Module-(B)|
-       "U_SHIPMINI2"
-       140
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Infra-Knife Module (B)")
-    #s(item$
-       |Infra=Knife-Module-(C)|
-       "U_SHIPMINI1"
-       60
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Infra-Knife Module (C)")
-    #s(item$
-       |Infra=Knife-Module-(S)|
-       "U_SHIPMINI4"
-       360
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Infra-Knife Module (S)")
-    #s(item$
-       Infrastructure-Ladder
-       "WALLFLOORLADDER"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Infrastructure Ladder")
-    #s(item$
-       Input-terminal
-       "MAINT_TECH4"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Input terminal")
-    #s(item$
-       Instability-Injector
-       "TRA_EXOTICS3"
-       15000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "Instability Injector")
-    #s(item$
-       Interior-Stairs
-       "CUBESTAIRS"
-       2
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Interior Stairs")
-    #s(item$
-       Internal-Freighter-Wall
-       "CUBEWALL_SPACE"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Internal Freighter Wall")
-    #s(item$
-       Ion-Battery
-       "POWERCELL"
-       200
-       (Substance:Catalyst Rarity:Uncommon Product:Consumable)
-       "Ion Battery")
-    #s(item$
-       Ion-Capacitor
-       "TRA_TECH3"
-       15000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "Ion Capacitor")
-    #s(item$ Ionised-Cobalt "CAVE2" 401 (Rarity:Rare) "Ionised Cobalt")
-    #s(item$
-       Iridesite
-       "ALLOY8"
-       150000
-       (Substance:Stellar Rarity:Rare Product:Tradeable)
-       "Iridesite")
-    #s(item$
-       Jetpack
-       "JET1"
-       1
-       (Technology:Suit TechnologyRarity:Always TechShopRarity:Impossible)
-       "Jetpack")
-    #s(item$ Kelp-Sac "PLANT_WATER" 41 (Rarity:Uncommon) "Kelp Sac")
-    #s(item$
-       Kinetic-Dynamo
-       "MAINT_FUEL5"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Kinetic Dynamo")
-    #s(item$
-       Korvax-Casing
-       "EXP_CURIO1"
-       22000
-       (Substance:Exotic Rarity:Rare Product:Curiousity)
-       "Korvax Casing")
-    #s(item$
-       Korvax-Convergence-Cube
-       "EXP_CURIO2"
-       13063
-       (Substance:Exotic Rarity:Common Product:Curiousity)
-       "Korvax Convergence Cube")
-    #s(item$
-       L=Shaped-Corridor
-       "CORRIDORL"
-       5
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "L-Shaped Corridor")
-    #s(item$
-       L=Shaped-Glass-Tunnel
-       "CORRIDORL_WATER"
-       3
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "L-Shaped Glass Tunnel")
-    #s(item$
-       Lab-Lamp
-       "BUILDLABLAMP"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Lab Lamp")
-    #s(item$
-       Ladder
-       "BUILDLADDER"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Ladder")
-    #s(item$
-       Landing-Pad
-       "BUILDLANDINGPAD"
-       10
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Landing Pad")
-    #s(item$
-       Large-Freighter-Room
-       "CUBEROOM_SPACE"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Large Freighter Room")
-    #s(item$
-       Large-Glass-Panel
-       "PANEL_GLASS"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Large Glass Panel")
-    #s(item$
-       Large-Hydroponic-Tray
-       "PLANTERMEGA"
-       10
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Large Hydroponic Tray")
-    #s(item$
-       Large-Monitor-Station
-       "LARGEDESK"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Large Monitor Station")
-    #s(item$
-       Large-Refiner
-       "BUILD_REFINER3"
-       10
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Large Refiner")
-    #s(item$
-       Large-Rocket-Tubes
-       "UT_ROCKETS"
-       1
-       (Technology:Ship TechnologyRarity:Rare TechShopRarity:Common)
-       "Large Rocket Tubes")
-    #s(item$
-       Large-Wall
-       "WALLTALL"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Large Wall")
-    #s(item$
-       Large-Wedge
-       "WEDGESHAPE"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Large Wedge")
-    #s(item$
-       Larval-Core
-       "FIENDCORE"
-       65000
-       (Substance:Exotic Rarity:Rare Product:Curiousity)
-       "Larval Core")
-    #s(item$
-       Launch-Thruster
-       "LAUNCHER"
-       1
-       (Technology:Ship TechnologyRarity:Always TechShopRarity:Impossible)
-       "Launch Thruster")
-    #s(item$
-       Lemmium
-       "ALLOY4"
-       25000
-       (Substance:Stellar Rarity:Rare Product:Tradeable)
-       "Lemmium")
-    #s(item$
-       Life-Support
-       "ENERGY"
-       1
-       (Technology:Suit TechnologyRarity:Always TechShopRarity:Impossible)
-       "Life Support")
-    #s(item$
-       Life-Support-Gel
-       "PRODFUEL2"
-       200
-       (Substance:Fuel Rarity:Uncommon Product:Consumable)
-       "Life Support Gel")
-    #s(item$
-       |Life-Support-Module-(A)|
-       "U_ENERGY2"
-       240
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Life Support Module (A)")
-    #s(item$
-       |Life-Support-Module-(B)|
-       "U_ENERGY1"
-       140
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Life Support Module (B)")
-    #s(item$
-       |Life-Support-Module-(S)|
-       "U_ENERGY3"
-       360
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Life Support Module (S)")
-    #s(item$
-       Light
-       "SMALLLIGHT"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Light")
-    #s(item$
-       Light-Balancer
-       "MAINT_FARM3"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Light Balancer")
-    #s(item$
-       Light-Table
-       "BUILDLIGHTTABLE"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Light Table")
-    #s(item$
-       Linking-Post
-       "CORNERPOST"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Linking Post")
-    #s(item$
-       Liquid-Explosive
-       "FARMPROD7"
-       800500
-       (Substance:Special Rarity:Rare Product:Tradeable)
-       "Liquid Explosive")
-    #s(item$
-       Living-Glass
-       "FARMPROD8"
-       566000
-       (Substance:Special Rarity:Rare Product:Tradeable)
-       "Living Glass")
-    #s(item$
-       Living-Pearl
-       "CLAMPEARL"
-       5050
-       (Substance:Exotic Rarity:Rare Product:Tradeable)
-       "Living Pearl")
-    #s(item$ Living-Slime "SPACEGUNK4" 20 (Rarity:Uncommon) "Living Slime")
-    #s(item$
-       Load-Balancer
-       "MAINT_TECH20"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Load Balancer")
-    #s(item$
-       Locked-Crate
-       "BUILDLCRATE"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Locked Crate")
-    #s(item$
-       Locker
-       "BUILDLOCKER"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Locker")
-    #s(item$
-       Locking-mechanism
-       "MAINT_TECH1"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Locking mechanism")
-    #s(item$
-       Loom-Damage
-       "WEAPSLOT_DMG6"
-       1
-       (Technology:Weapon
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Loom Damage")
-    #s(item$
-       Lost-Bathysphere
-       "SPEC_DIVEHELMET"
-       1000
-       (Substance:Exotic Rarity:Common Product:Consumable)
-       "Lost Bathysphere")
-    #s(item$
-       Lubricant
-       "FARMPROD2"
-       110000
-       (Substance:Special Rarity:Rare Product:Tradeable)
-       "Lubricant")
-    #s(item$
-       Magnetic-Lock
-       "MAINT_TECH2"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Magnetic Lock")
-    #s(item$
-       Magnetised-Ferrite
-       "LAND3"
-       82
-       (Rarity:Uncommon)
-       "Magnetised Ferrite")
-    #s(item$
-       Magno=Gold
-       "ALLOY5"
-       25000
-       (Substance:Stellar Rarity:Rare Product:Tradeable)
-       "Magno-Gold")
-    #s(item$
-       Marine-Shelter
-       "WATERBUBBLE"
-       10
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Marine Shelter")
-    #s(item$ Marrow-Bulb "PLANT_CAVE" 41 (Rarity:Uncommon) "Marrow Bulb")
-    #s(item$
-       Mass-Accelerator
-       "UT_RAIL"
-       1
-       (Technology:Weapon TechnologyRarity:Common TechShopRarity:Common)
-       "Mass Accelerator")
-    #s(item$
-       Master-Circuit
-       "MAINT_TECH18"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Master Circuit")
-    #s(item$
-       Medium-Refiner
-       "BUILD_REFINER2"
-       10
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Medium Refiner")
-    #s(item$
-       Membrane-Battery
-       "MAINT_FUEL2"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Membrane Battery")
-    #s(item$
-       Message-Module
-       "MESSAGEMODULE"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Message Module")
-    #s(item$
-       Metal-Arch
-       "M_ARCH"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Metal Arch")
-    #s(item$
-       Metal-Door-Frame
-       "M_DOOR"
-       2
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Metal Door Frame")
-    #s(item$
-       Metal-Doorway
-       "M_DOOR_H"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Metal Doorway")
-    #s(item$
-       Metal-Floor-Panel
-       "M_FLOOR"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Metal Floor Panel")
-    #s(item$
-       Metal-Frontage
-       "M_DOORWINDOW"
-       3
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Metal Frontage")
-    #s(item$
-       Metal-Half-Arch
-       "M_ARCH_H"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Metal Half Arch")
-    #s(item$
-       Metal-Half-Ramp
-       "M_RAMP_H"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Metal Half Ramp")
-    #s(item$
-       Metal-Plating
-       "CASING"
-       800
-       (Substance:Catalyst Rarity:Common Product:Component)
-       "Metal Plating")
-    #s(item$
-       Metal-Ramp
-       "M_RAMP"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Metal Ramp")
-    #s(item$
-       Metal-Roof
-       "M_ROOF"
-       2
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Metal Roof")
-    #s(item$
-       Metal-Roof-Corner
-       "M_ROOF_C"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Metal Roof Corner")
-    #s(item$
-       Metal-Roof-Panel
-       "M_ROOF_M"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Metal Roof Panel")
-    #s(item$
-       Metal-Wall
-       "M_WALL"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Metal Wall")
-    #s(item$
-       Metal-Window-Panel
-       "M_WALL_WINDOW"
-       2
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Metal Window Panel")
-    #s(item$
-       Metal=Framed-Glass-Panel
-       "M_GFLOOR"
-       3
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Metal-Framed Glass Panel")
-    #s(item$
-       Microprocessor
-       "MICROCHIP"
-       2000
-       (Substance:Catalyst Rarity:Rare Product:Component)
-       "Microprocessor")
-    #s(item$
-       Mind-Arc
-       "MIND_ARC"
-       1000
-       (Substance:Special Rarity:Rare Product:Curiousity)
-       "Mind Arc")
-    #s(item$
-       Mind-Blown
-       "SPEC_EMOTE01"
-       1500
-       (Substance:Exotic Rarity:Common Product:Emote)
-       "Mind Blown")
-    #s(item$
-       Mind-Control-Device
-       "FRIG_BOOST_TRA"
-       75000
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Mind Control Device")
-    #s(item$
-       Mineral-Compressor
-       "FRIG_BOOST_MIN"
-       75000
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Mineral Compressor")
-    #s(item$
-       Mining-Beam
-       "LASER"
-       1
-       (Technology:Weapon TechnologyRarity:Always TechShopRarity:Always)
-       "Mining Beam")
-    #s(item$
-       |Mining-Beam-Module-(A)|
-       "U_LASER3"
-       240
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Mining Beam Module (A)")
-    #s(item$
-       |Mining-Beam-Module-(B)|
-       "U_LASER2"
-       140
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Mining Beam Module (B)")
-    #s(item$
-       |Mining-Beam-Module-(C)|
-       "U_LASER1"
-       60
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Mining Beam Module (C)")
-    #s(item$
-       |Mining-Beam-Module-(S)|
-       "U_LASER4"
-       360
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Mining Beam Module (S)")
-    #s(item$
-       Modified-Quanta
-       "ATLAS_SEED_9"
-       1000
-       (Substance:Stellar Rarity:Rare Product:Curiousity)
-       "Modified Quanta")
-    #s(item$
-       Monitor-Station
-       "MONITORDESK"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Monitor Station")
-    #s(item$
-       Moon-Pool-Floor
-       "MOONPOOL"
-       10
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Moon Pool Floor")
-    #s(item$ Mordite "CREATURE1" 40 (Rarity:Common) "Mordite")
-    #s(item$
-       Mordite-Root
-       "CREATUREPLANT"
-       3
-       (Substance:BuildingPart Rarity:Rare Product:BuildingPart)
-       "Mordite Root")
-    #s(item$
-       |Movement-Module-(A)|
-       "U_JETBOOST3"
-       240
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Movement Module (A)")
-    #s(item$
-       |Movement-Module-(B)|
-       "U_JETBOOST2"
-       140
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Movement Module (B)")
-    #s(item$
-       |Movement-Module-(C)|
-       "U_JETBOOST1"
-       60
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Movement Module (C)")
-    #s(item$
-       |Movement-Module-(S)|
-       "U_JETBOOST4"
-       360
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Movement Module (S)")
-    #s(item$
-       Muster-Point
-       "SHIPSUMMON"
-       10
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Muster Point")
-    #s(item$
-       NPCEXPLORER001
-       "NPCEXPLORER001"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "NPCEXPLORER001")
-    #s(item$
-       Nada-Decal
-       "SPEC_DECAL04"
-       400
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Nada Decal")
-    #s(item$ Nanite-Cluster "TECHFRAG" 20 (Rarity:Rare) "Nanite Cluster")
-    #s(item$
-       Nanotube-Crate
-       "TRA_ALLOY1"
-       1000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "Nanotube Crate")
-    #s(item$
-       Nautilon-Cannon
-       "SUB_GUN"
-       1
-       (Technology:Submarine
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Nautilon Cannon")
-    #s(item$
-       |Nautilon-Cannon-Module-(A)|
-       "U_EXO_SUBGUN3"
-       240
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Nautilon Cannon Module (A)")
-    #s(item$
-       |Nautilon-Cannon-Module-(B)|
-       "U_EXO_SUBGUN2"
-       140
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Nautilon Cannon Module (B)")
-    #s(item$
-       |Nautilon-Cannon-Module-(C)|
-       "U_EXO_SUBGUN1"
-       60
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Nautilon Cannon Module (C)")
-    #s(item$
-       |Nautilon-Cannon-Module-(S)|
-       "U_EXO_SUBGUN4"
-       360
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Nautilon Cannon Module (S)")
-    #s(item$
-       Nautilon-Chamber
-       "GARAGE_SUB"
-       10
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Nautilon Chamber")
-    #s(item$
-       Navigation-Data
-       "NAV_DATA"
-       1000
-       (Substance:Special Rarity:Rare Product:Curiousity)
-       "Navigation Data")
-    #s(item$
-       Network-Interface
-       "MAINT_TECH21"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Network Interface")
-    #s(item$
-       Neural-Duct
-       "TRA_EXOTICS5"
-       50000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "Neural Duct")
-    #s(item$
-       Neural-Stimulator
-       "UT_JET"
-       1
-       (Technology:Suit TechnologyRarity:Common TechShopRarity:Common)
-       "Neural Stimulator")
-    #s(item$
-       Neutron-Microscope
-       "TRA_EXOTICS2"
-       6000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "Neutron Microscope")
-    #s(item$
-       NipNip
-       "NIPPLANT"
-       3
-       (Substance:BuildingPart Rarity:Rare Product:BuildingPart)
-       "NipNip")
-    #s(item$
-       NipNip-Buds
-       "NIPNIPBUDS"
-       17776
-       (Substance:Exotic Rarity:Rare Product:Curiousity)
-       "NipNip Buds")
-    #s(item$ Nitrogen "GAS3" 20 (Rarity:Rare) "Nitrogen")
-    #s(item$
-       Nitrogen-Salt
-       "REACTION3"
-       50000
-       (Substance:Special Rarity:Rare Product:Tradeable)
-       "Nitrogen Salt")
-    #s(item$
-       No-Problem
-       "SPEC_EMOTE05"
-       1500
-       (Substance:Exotic Rarity:Common Product:Emote)
-       "No Problem")
-    #s(item$
-       Nomad-Geobay
-       "GARAGE_S"
-       10
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Nomad Geobay")
-    #s(item$
-       Nonlinear-Optics
-       "UT_SHIPGUN"
-       1
-       (Technology:Ship TechnologyRarity:Rare TechShopRarity:Common)
-       "Nonlinear Optics")
-    #s(item$
-       Noospheric-Orb
-       "ATLAS_SEED_3"
-       1000
-       (Substance:Stellar Rarity:Rare Product:Curiousity)
-       "Noospheric Orb")
-    #s(item$
-       Novae-Reclaiment
-       "ATLAS_SEED_8"
-       1000
-       (Substance:Stellar Rarity:Rare Product:Curiousity)
-       "Novae Reclaiment")
-    #s(item$
-       Null-Decal
-       "SPEC_DECAL08"
-       400
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Null Decal")
-    #s(item$
-       Nutrient-Distributor
-       "MAINT_FARM5"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Nutrient Distributor")
-    #s(item$
-       Obsolete-Technology
-       "OBSOLETE"
-       1
-       (Technology:Suit TechnologyRarity:Impossible TechShopRarity:Impossible)
-       "Obsolete Technology")
-    #s(item$
-       Octa=Cabinet
-       "OCTACABINET"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Octa-Cabinet")
-    #s(item$
-       Ohmic-Gel
-       "TRA_ENERGY3"
-       15000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "Ohmic Gel")
-    #s(item$
-       Optical-Solvent
-       "TRA_ALLOY3"
-       15000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "Optical Solvent")
-    #s(item$
-       Orange-Wall-Screen
-       "WALLSCREENB2"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Orange Wall Screen")
-    #s(item$
-       Organic-Catalyst
-       "COMPOUND1"
-       320000
-       (Substance:Special Rarity:Rare Product:Tradeable)
-       "Organic Catalyst")
-    #s(item$
-       Organic-Piping
-       "TRA_EXOTICS4"
-       30000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "Organic Piping")
-    #s(item$
-       Oscilloscope
-       "BOXEDSCREEN"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Oscilloscope")
-    #s(item$
-       Osmotic-Generator
-       "SUB_RECHARGE"
-       1
-       (Technology:Submarine
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Osmotic Generator")
-    #s(item$
-       Output-screen
-       "MAINT_TECH9"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Output screen")
-    #s(item$ Oxygen "OXYGEN" 34 (Rarity:Common) "Oxygen")
-    #s(item$
-       Oxygen-Capsule
-       "PRODFUEL1"
-       350
-       (Substance:Fuel Rarity:Rare Product:Consumable)
-       "Oxygen Capsule")
-    #s(item$
-       Oxygen-Filter
-       "OXY_CRAFT"
-       615
-       (Substance:Stellar Rarity:Uncommon Product:Component)
-       "Oxygen Filter")
-    #s(item$
-       Oxygen-Harvester
-       "O2_HARVESTER"
-       10
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Oxygen Harvester")
-    #s(item$
-       Oxygen-Recycler
-       "UT_ENERGY"
-       1
-       (Technology:Suit TechnologyRarity:Common TechShopRarity:Common)
-       "Oxygen Recycler")
-    #s(item$
-       Oxygen-Rerouter
-       "UT_WATERENERGY"
-       1
-       (Technology:Suit TechnologyRarity:Common TechShopRarity:Common)
-       "Oxygen Rerouter")
-    #s(item$ Paraffinium "LUSH1" 62 (Rarity:Uncommon) "Paraffinium")
-    #s(item$
-       Paving
-       "BUILDPAVING"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Paving")
-    #s(item$
-       Pearl-Offering
-       "MAINT_SEALOCK1"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Pearl Offering")
-    #s(item$
-       Personal-Forcefield
-       "GROUND_SHIELD"
-       1
-       (Technology:Weapon TechnologyRarity:Common TechShopRarity:Common)
-       "Personal Forcefield")
-    #s(item$
-       Phase-Beam
-       "SHIPLAS1"
-       1
-       (Technology:Ship TechnologyRarity:Rare TechShopRarity:Common)
-       "Phase Beam")
-    #s(item$
-       |Phase-Beam-Module-(A)|
-       "U_SHIPLAS3"
-       240
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Phase Beam Module (A)")
-    #s(item$
-       |Phase-Beam-Module-(B)|
-       "U_SHIPLAS2"
-       140
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Phase Beam Module (B)")
-    #s(item$
-       |Phase-Beam-Module-(C)|
-       "U_SHIPLAS1"
-       60
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Phase Beam Module (C)")
-    #s(item$
-       |Phase-Beam-Module-(S)|
-       "U_SHIPLAS4"
-       360
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Phase Beam Module (S)")
-    #s(item$ Phosphorus "HOT1" 62 (Rarity:Uncommon) "Phosphorus")
-    #s(item$
-       Photic-Jade
-       "ATLAS_SEED_6"
-       1000
-       (Substance:Stellar Rarity:Rare Product:Curiousity)
-       "Photic Jade")
-    #s(item$
-       Photon-Cannon
-       "SHIPGUN1"
-       1
-       (Technology:Ship TechnologyRarity:Always TechShopRarity:Impossible)
-       "Photon Cannon")
-    #s(item$
-       |Photon-Cannon-Module-(A)|
-       "U_SHIPGUN3"
-       240
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Photon Cannon Module (A)")
-    #s(item$
-       |Photon-Cannon-Module-(B)|
-       "U_SHIPGUN2"
-       140
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Photon Cannon Module (B)")
-    #s(item$
-       |Photon-Cannon-Module-(C)|
-       "U_SHIPGUN1"
-       60
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Photon Cannon Module (C)")
-    #s(item$
-       |Photon-Cannon-Module-(S)|
-       "U_SHIPGUN4"
-       360
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Photon Cannon Module (S)")
-    #s(item$
-       Photonix-Core
-       "PHOTONIX_CORE"
-       1
-       (Technology:Ship TechnologyRarity:Impossible TechShopRarity:Impossible)
-       "Photonix Core")
-    #s(item$
-       Photovoltaic-Panel
-       "MAINT_TECH24"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Photovoltaic Panel")
-    #s(item$
-       Pilgrim-Geobay
-       "GARAGE_B"
-       10
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Pilgrim Geobay")
-    #s(item$
-       Pipe
-       "PIPESHAPE"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Pipe")
-    #s(item$
-       Plasma-Launcher
-       "GRENADE"
-       1
-       (Technology:Weapon TechnologyRarity:Common TechShopRarity:Common)
-       "Plasma Launcher")
-    #s(item$
-       |Plasma-Launcher-Module-(A)|
-       "U_GRENADE3"
-       240
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Plasma Launcher Module (A)")
-    #s(item$
-       |Plasma-Launcher-Module-(B)|
-       "U_GRENADE2"
-       140
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Plasma Launcher Module (B)")
-    #s(item$
-       |Plasma-Launcher-Module-(C)|
-       "U_GRENADE1"
-       60
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Plasma Launcher Module (C)")
-    #s(item$
-       |Plasma-Launcher-Module-(S)|
-       "U_GRENADE4"
-       360
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Plasma Launcher Module (S)")
-    #s(item$
-       Plasma-Resonator
-       "LASER_XO"
-       1
-       (Technology:Weapon
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Plasma Resonator")
-    #s(item$ Platinum "ASTEROID3" 303 (Rarity:Rare) "Platinum")
-    #s(item$
-       Polo-Decal
-       "SPEC_DECAL05"
-       400
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Polo Decal")
-    #s(item$
-       Poly-Fibre
-       "FARMPROD5"
-       130000
-       (Substance:Special Rarity:Rare Product:Tradeable)
-       "Poly Fibre")
-    #s(item$
-       Polychromatic-Zirconium
-       "TRA_MINERALS4"
-       30000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "Polychromatic Zirconium")
-    #s(item$
-       Portable-Reactor
-       "MEGAPROD1"
-       4200000
-       (Substance:Special Rarity:Rare Product:Tradeable)
-       "Portable Reactor")
-    #s(item$
-       Portable-Refiner
-       "BUILD_REFINER1"
-       10
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Portable Refiner")
-    #s(item$
-       Portal-Glyph
-       "MAINT_PORTAL1"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Portal Glyph")
-    #s(item$
-       Positron-Ejector
-       "SHIPSHOTGUN"
-       1
-       (Technology:Ship TechnologyRarity:Impossible TechShopRarity:Common)
-       "Positron Ejector")
-    #s(item$
-       |Positron-Module-(A)|
-       "U_SHIPSHOT3"
-       240
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Positron Module (A)")
-    #s(item$
-       |Positron-Module-(B)|
-       "U_SHIPSHOT2"
-       140
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Positron Module (B)")
-    #s(item$
-       |Positron-Module-(C)|
-       "U_SHIPSHOT1"
-       60
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Positron Module (C)")
-    #s(item$
-       |Positron-Module-(S)|
-       "U_SHIPSHOT4"
-       360
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Positron Module (S)")
-    #s(item$
-       Potted-Plant
-       "PLANTPOT"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Potted Plant")
-    #s(item$
-       Power-Condenser
-       "MAINT_FUEL3"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Power Condenser")
-    #s(item$
-       Power-Distributor
-       "MAINT_TECH19"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Power Distributor")
-    #s(item$
-       Pressure-Chamber
-       "MAINT_TECH17"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Pressure Chamber")
-    #s(item$
-       Projectile-Ammunition
-       "AMMO"
-       5
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Projectile Ammunition")
-    #s(item$ Pugneum "ROBOT1" 138 (Rarity:Rare) "Pugneum")
-    #s(item$
-       Pulse-Engine
-       "SHIPJUMP1"
-       1
-       (Technology:Ship TechnologyRarity:Always TechShopRarity:Impossible)
-       "Pulse Engine")
-    #s(item$
-       |Pulse-Engine-Module-(A)|
-       "U_PULSE3"
-       240
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Pulse Engine Module (A)")
-    #s(item$
-       |Pulse-Engine-Module-(B)|
-       "U_PULSE2"
-       140
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Pulse Engine Module (B)")
-    #s(item$
-       |Pulse-Engine-Module-(C)|
-       "U_PULSE1"
-       60
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Pulse Engine Module (C)")
-    #s(item$
-       |Pulse-Engine-Module-(S)|
-       "U_PULSE4"
-       360
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Pulse Engine Module (S)")
-    #s(item$
-       Pulse-Spitter
-       "SMG"
-       1
-       (Technology:Weapon TechnologyRarity:Common TechShopRarity:Common)
-       "Pulse Spitter")
-    #s(item$
-       |Pulse-Spitter-Module-(A)|
-       "U_SMG3"
-       240
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Pulse Spitter Module (A)")
-    #s(item$
-       |Pulse-Spitter-Module-(B)|
-       "U_SMG2"
-       140
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Pulse Spitter Module (B)")
-    #s(item$
-       |Pulse-Spitter-Module-(C)|
-       "U_SMG1"
-       60
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Pulse Spitter Module (C)")
-    #s(item$
-       |Pulse-Spitter-Module-(S)|
-       "U_SMG4"
-       360
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Pulse Spitter Module (S)")
-    #s(item$ Pure-Ferrite "LAND2" 28 (Rarity:Uncommon) "Pure Ferrite")
-    #s(item$
-       Pyramid
-       "PYRAMIDSHAPE"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Pyramid")
-    #s(item$ Pyrite "DUSTY1" 62 (Rarity:Uncommon) "Pyrite")
-    #s(item$
-       Quad-Servo
-       "QUAD_PROD"
-       20000
-       (Substance:Special Rarity:Uncommon Product:Component)
-       "Quad Servo")
-    #s(item$
-       Quantum-Accelerator
-       "TRA_TECH5"
-       50000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "Quantum Accelerator")
-    #s(item$
-       Quantum-Processor
-       "MEGAPROD2"
-       4400000
-       (Substance:Special Rarity:Rare Product:Tradeable)
-       "Quantum Processor")
-    #s(item$
-       Race-Force-Amplifier
-       "RACE_BOOSTER"
-       10
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Race Force Amplifier")
-    #s(item$
-       Race-Initiator
-       "RACE_START"
-       10
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Race Initiator")
-    #s(item$
-       Race-Obstacle
-       "RACE_RAMP"
-       10
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Race Obstacle")
-    #s(item$
-       Radiation-Leak
-       "SHIPSLOT_DMG4"
-       1
-       (Technology:Ship TechnologyRarity:Impossible TechShopRarity:Impossible)
-       "Radiation Leak")
-    #s(item$
-       |Radiation-Protection-Module-(A)|
-       "U_RAD2"
-       240
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Radiation Protection Module (A)")
-    #s(item$
-       |Radiation-Protection-Module-(B)|
-       "U_RAD1"
-       140
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Radiation Protection Module (B)")
-    #s(item$
-       |Radiation-Protection-Module-(S)|
-       "U_RAD3"
-       360
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Radiation Protection Module (S)")
-    #s(item$ Radon "GAS2" 20 (Rarity:Uncommon) "Radon")
-    #s(item$
-       Rare-Metal-Element
-       "LANDPROD3"
-       4200
-       (Substance:Exotic Rarity:Rare Product:Curiousity)
-       "Rare Metal Element")
-    #s(item$
-       Re=latticed-Arc-Crystal
-       "TRA_MINERALS5"
-       50000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "Re-latticed Arc Crystal")
-    #s(item$
-       Refinery-Output
-       "MAINT_REFINER"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Refinery Output")
-    #s(item$
-       Remembrance
-       "ATLASSUIT"
-       1
-       (Technology:Suit TechnologyRarity:Impossible TechShopRarity:Impossible)
-       "Remembrance")
-    #s(item$ Residual-Goop "SPACEGUNK1" 20 (Rarity:Common) "Residual Goop")
-    #s(item$
-       Roamer-Geobay
-       "GARAGE_M"
-       10
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Roamer Geobay")
-    #s(item$
-       Robotic-Arm
-       "ROBOTICARM"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Robotic Arm")
-    #s(item$
-       Robotic-Companion
-       "BASE_ROBOTOY"
-       800
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Robotic Companion")
-    #s(item$
-       Rocket-Boots
-       "UT_JUMP"
-       1
-       (Technology:Suit TechnologyRarity:Common TechShopRarity:Common)
-       "Rocket Boots")
-    #s(item$
-       Rocket-Launcher
-       "SHIPROCKETS"
-       1
-       (Technology:Ship TechnologyRarity:Common TechShopRarity:Common)
-       "Rocket Launcher")
-    #s(item$
-       Roof-Platform
-       "ROOMFLOOR"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Roof Platform")
-    #s(item$ Runaway-Mould "SPACEGUNK2" 20 (Rarity:Common) "Runaway Mould")
-    #s(item$
-       Rusted-Circuits
-       "SHIPSLOT_DMG2"
-       1
-       (Technology:Ship TechnologyRarity:Impossible TechShopRarity:Impossible)
-       "Rusted Circuits")
-    #s(item$ Rusted-Metal "SPACEGUNK3" 20 (Rarity:Uncommon) "Rusted Metal")
-    #s(item$
-       Rusted-Power-Core
-       "WEAPSLOT_DMG4"
-       1
-       (Technology:Weapon
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Rusted Power Core")
-    #s(item$
-       Sac-Venom
-       "SACVENOM"
-       12300
-       (Substance:Exotic Rarity:Rare Product:Tradeable)
-       "Sac Venom")
-    #s(item$
-       Safety-Panel
-       "MAINT_TECH22"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Safety Panel")
-    #s(item$ Salt "WATER1" 299 (Rarity:Common) "Salt")
-    #s(item$
-       Salt-Refractor
-       "WATER_CRAFT"
-       30500
-       (Substance:Stellar Rarity:Uncommon Product:Component)
-       "Salt Refractor")
-    #s(item$
-       Salvaged-Technology
-       "BP_SALVAGE"
-       50000
-       (Substance:Exotic Rarity:Rare Product:Curiousity)
-       "Salvaged Technology")
-    #s(item$
-       Save-Point
-       "BUILDSAVE"
-       2
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Save Point")
-    #s(item$
-       Scanner
-       "SCAN1"
-       1
-       (Technology:Weapon TechnologyRarity:Always TechShopRarity:Impossible)
-       "Scanner")
-    #s(item$
-       |Scanner-Module-(A)|
-       "U_SCANNER3"
-       240
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Scanner Module (A)")
-    #s(item$
-       |Scanner-Module-(B)|
-       "U_SCANNER2"
-       140
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Scanner Module (B)")
-    #s(item$
-       |Scanner-Module-(C)|
-       "U_SCANNER1"
-       60
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Scanner Module (C)")
-    #s(item$
-       |Scanner-Module-(S)|
-       "U_SCANNER4"
-       360
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Scanner Module (S)")
-    #s(item$
-       Scatter-Blaster
-       "SHOTGUN"
-       1
-       (Technology:Weapon TechnologyRarity:Common TechShopRarity:Common)
-       "Scatter Blaster")
-    #s(item$
-       |Scatter-Blaster-Module-(A)|
-       "U_SHOTGUN3"
-       240
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Scatter Blaster Module (A)")
-    #s(item$
-       |Scatter-Blaster-Module-(B)|
-       "U_SHOTGUN2"
-       140
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Scatter Blaster Module (B)")
-    #s(item$
-       |Scatter-Blaster-Module-(C)|
-       "U_SHOTGUN1"
-       60
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Scatter Blaster Module (C)")
-    #s(item$
-       |Scatter-Blaster-Module-(S)|
-       "U_SHOTGUN4"
-       360
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Scatter Blaster Module (S)")
-    #s(item$
-       Science-Terminal
-       "NPCSCIENCETERM"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Science Terminal")
-    #s(item$
-       Security-Alarm
-       "MAINT_TECH11"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Security Alarm")
-    #s(item$
-       Self=Repairing-Heridium
-       "TRA_ALLOY2"
-       6000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "Self-Repairing Heridium")
-    #s(item$
-       Semiconductor
-       "COMPOUND2"
-       320000
-       (Substance:Special Rarity:Rare Product:Tradeable)
-       "Semiconductor")
-    #s(item$
-       Server
-       "SERVERSTACK"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Server")
-    #s(item$
-       Servo-Arm
-       "MAINT_TECH15"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Servo Arm")
-    #s(item$
-       Shattered-Bulwark
-       "SHIPSLOT_DMG3"
-       1
-       (Technology:Ship TechnologyRarity:Impossible TechShopRarity:Impossible)
-       "Shattered Bulwark")
-    #s(item$
-       Shattered-Power-Core
-       "EXOPOD_TECH3"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Shattered Power Core")
-    #s(item$
-       Shelf-Panel
-       "SHELFPANEL"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Shelf Panel")
-    #s(item$
-       Shell-Greaser
-       "UT_SHOT"
-       1
-       (Technology:Weapon TechnologyRarity:Common TechShopRarity:Common)
-       "Shell Greaser")
-    #s(item$
-       Shield-Lattice
-       "UT_PROTECT"
-       1
-       (Technology:Suit TechnologyRarity:Common TechShopRarity:Common)
-       "Shield Lattice")
-    #s(item$
-       |Shield-Module-(A)|
-       "U_SHIELDBOOST3"
-       240
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Shield Module (A)")
-    #s(item$
-       |Shield-Module-(B)|
-       "U_SHIELDBOOST2"
-       140
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Shield Module (B)")
-    #s(item$
-       |Shield-Module-(C)|
-       "U_SHIELDBOOST1"
-       60
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Shield Module (C)")
-    #s(item$
-       |Shield-Module-(S)|
-       "U_SHIELDBOOST4"
-       360
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Shield Module (S)")
-    #s(item$
-       Short-Circuit
-       "WEAPSLOT_DMG1"
-       1
-       (Technology:Weapon
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Short Circuit")
-    #s(item$
-       Short-Concrete-Wall
-       "C_WALL_Q_H"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Short Concrete Wall")
-    #s(item$
-       Short-Metal-Wall
-       "M_WALL_Q_H"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Short Metal Wall")
-    #s(item$
-       Short-Wooden-Wall
-       "W_WALL_Q_H"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Short Wooden Wall")
-    #s(item$
-       Shutter-Door
-       "WALLDOOR"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Shutter Door")
-    #s(item$
-       Side-Panel
-       "BUILDSIDEPANEL"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Side Panel")
-    #s(item$
-       Signal-Booster
-       "BUILDSIGNAL"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Signal Booster")
-    #s(item$ Silver "ASTEROID1" 101 (Rarity:Common) "Silver")
-    #s(item$
-       Silver-Astronaut-Statue
-       "STATUE_ASTRO_S"
-       400
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Silver Astronaut Statue")
-    #s(item$
-       Silver-Atlas-Statue
-       "STATUE_ATLAS_S"
-       400
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Silver Atlas Statue")
-    #s(item$
-       Silver-Blob-Statue
-       "STATUE_BLOB_S"
-       400
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Silver Blob Statue")
-    #s(item$
-       Silver-Diplo-Statue
-       "STATUE_DIP_S"
-       400
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Silver Diplo Statue")
-    #s(item$
-       Silver-Fighter-Statue
-       "STATUE_SHIP_S"
-       400
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Silver Fighter Statue")
-    #s(item$
-       Silver-Gek-Statue
-       "STATUE_GEK_S"
-       400
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Silver Gek Statue")
-    #s(item$
-       Silver-Walker-Statue
-       "STATUE_WALK_S"
-       400
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Silver Walker Statue")
-    #s(item$
-       Simple-Desk
-       "BUILDSIMPLEDESK"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Simple Desk")
-    #s(item$
-       Sloping-Concrete-Panel
-       "C_WALLDIAGONAL"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Sloping Concrete Panel")
-    #s(item$
-       Sloping-Metal-Panel
-       "M_WALLDIAGONAL"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Sloping Metal Panel")
-    #s(item$
-       Sloping-Wood-Panel
-       "W_WALLDIAGONAL"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Sloping Wood Panel")
-    #s(item$
-       Small-Aquarium
-       "BASE_AQUARIUM"
-       800
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Small Aquarium")
-    #s(item$
-       Small-Concrete-Door
-       "C_SDOOR"
-       2
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Small Concrete Door")
-    #s(item$
-       Small-Concrete-Panel
-       "C_FLOOR_Q"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Small Concrete Panel")
-    #s(item$
-       Small-Concrete-Wall
-       "C_WALL_Q"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Small Concrete Wall")
-    #s(item$
-       Small-Crate
-       "BUILDAMCRATE"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Small Crate")
-    #s(item$
-       Small-Metal-Door
-       "M_SDOOR"
-       2
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Small Metal Door")
-    #s(item$
-       Small-Metal-Panel
-       "M_FLOOR_Q"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Small Metal Panel")
-    #s(item$
-       Small-Metal-Wall
-       "M_WALL_Q"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Small Metal Wall")
-    #s(item$
-       Small-Wedge
-       "WEDGESMALLSHAPE"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Small Wedge")
-    #s(item$
-       Small-Wood-Panel
-       "W_FLOOR_Q"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Small Wood Panel")
-    #s(item$
-       Small-Wooden-Door
-       "W_SDOOR"
-       2
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Small Wooden Door")
-    #s(item$
-       Small-Wooden-Wall
-       "W_WALL_Q"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Small Wooden Wall")
-    #s(item$ Sodium "CATALYST1" 41 (Rarity:Uncommon) "Sodium")
-    #s(item$
-       Sodium-Diode
-       "CATA_CRAFT"
-       3500
-       (Substance:Stellar Rarity:Uncommon Product:Component)
-       "Sodium Diode")
-    #s(item$ Sodium-Nitrate "CATALYST2" 82 (Rarity:Rare) "Sodium Nitrate")
-    #s(item$
-       Sofa
-       "BUILDSOFA"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Sofa")
-    #s(item$
-       Soil-De=Wormer
-       "MAINT_FARM1"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Soil De-Wormer")
-    #s(item$ Solanium "PLANT_HOT" 70 (Rarity:Rare) "Solanium")
-    #s(item$
-       Solar-Vine
-       "SCORCHEDPLANT"
-       3
-       (Substance:BuildingPart Rarity:Rare Product:BuildingPart)
-       "Solar Vine")
-    #s(item$
-       Solenoid
-       "MAINT_TECH16"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Solenoid")
-    #s(item$
-       Solid-Cube
-       "CUBESOLID"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Solid Cube")
-    #s(item$
-       Spark-Canister
-       "TRA_ENERGY1"
-       1000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "Spark Canister")
-    #s(item$
-       Sparse-Horizon-Helmet
-       "SPEC_HELMET01"
-       3000
-       (Substance:Exotic Rarity:Common Product:CustomisationPart)
-       "Sparse Horizon Helmet")
-    #s(item$
-       Sphere
-       "SPHERESHAPE"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Sphere")
-    #s(item$
-       Spindle-Tree
-       "BASE_TREE02"
-       500
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Spindle Tree")
-    #s(item$
-       Spring-Casing
-       "MAINT_TECH12"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Spring Casing")
-    #s(item$
-       Square-Deepwater-Chamber
-       "MAINROOMCUBE_W"
-       6
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Square Deepwater Chamber")
-    #s(item$
-       Square-Room
-       "MAINROOMCUBE"
-       3
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Square Room")
-    #s(item$
-       Standing-Planter
-       "CARBONPLANTER"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Standing Planter")
-    #s(item$
-       Star-Bramble
-       "LUSHPLANT"
-       3
-       (Substance:BuildingPart Rarity:Rare Product:BuildingPart)
-       "Star Bramble")
-    #s(item$ Star-Bulb "PLANT_LUSH" 32 (Rarity:Rare) "Star Bulb")
-    #s(item$
-       Star-Seed
-       "STARSUIT"
-       1
-       (Technology:Suit TechnologyRarity:Impossible TechShopRarity:Impossible)
-       "Star Seed")
-    #s(item$
-       Starship-Launch-Fuel
-       "LAUNCHFUEL"
-       450
-       (Substance:Fuel Rarity:Uncommon Product:Consumable)
-       "Starship Launch Fuel")
-    #s(item$
-       Starship-Race-Initiator
-       "RACE_START_SHIP"
-       10
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Starship Race Initiator")
-    #s(item$
-       |Starship-Shield-Module-(A)|
-       "U_SHIPSHIELD3"
-       240
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Starship Shield Module (A)")
-    #s(item$
-       |Starship-Shield-Module-(B)|
-       "U_SHIPSHIELD2"
-       140
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Starship Shield Module (B)")
-    #s(item$
-       |Starship-Shield-Module-(C)|
-       "U_SHIPSHIELD1"
-       60
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Starship Shield Module (C)")
-    #s(item$
-       |Starship-Shield-Module-(S)|
-       "U_SHIPSHIELD4"
-       360
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Starship Shield Module (S)")
-    #s(item$
-       Stasis-Device
-       "ULTRAPROD2"
-       15600000
-       (Substance:Special Rarity:Rare Product:Tradeable)
-       "Stasis Device")
-    #s(item$
-       State-Phasure
-       "ATLAS_SEED_7"
-       1000
-       (Substance:Stellar Rarity:Rare Product:Curiousity)
-       "State Phasure")
-    #s(item$
-       Storage-Container
-       "CONTAINER0"
-       5
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Storage Container")
-    #s(item$
-       Storage-Panel
-       "STORAGEPANEL"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Storage Panel")
-    #s(item$
-       Straight-Corridor
-       "CORRIDOR"
-       5
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Straight Corridor")
-    #s(item$ Sulphurine "GAS1" 20 (Rarity:Common) "Sulphurine")
-    #s(item$
-       Superconducting-Fibre
-       "TRA_ALLOY5"
-       50000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "Superconducting Fibre")
-    #s(item$
-       Superconductive-Lock
-       "MAINT_TECH3"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Superconductive Lock")
-    #s(item$
-       Superconductor
-       "COMPOUND5"
-       1500000
-       (Substance:Special Rarity:Rare Product:Tradeable)
-       "Superconductor")
-    #s(item$
-       Superoxide-Crystal
-       "OXYPROD3"
-       5100
-       (Substance:Exotic Rarity:Rare Product:Curiousity)
-       "Superoxide Crystal")
-    #s(item$
-       Swept-Sofa
-       "BUILDSOFA2"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Swept Sofa")
-    #s(item$
-       T=Shaped-Corridor
-       "CORRIDORT"
-       5
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "T-Shaped Corridor")
-    #s(item$
-       T=Shaped-Glass-Tunnel
-       "CORRIDORT_WATER"
-       3
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "T-Shaped Glass Tunnel")
-    #s(item$
-       TRA_COMMODITY1
-       "TRA_COMMODITY1"
-       1000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "TRA_COMMODITY1")
-    #s(item$
-       TRA_COMMODITY2
-       "TRA_COMMODITY2"
-       6000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "TRA_COMMODITY2")
-    #s(item$
-       TRA_COMMODITY3
-       "TRA_COMMODITY3"
-       15000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "TRA_COMMODITY3")
-    #s(item$
-       TRA_COMMODITY4
-       "TRA_COMMODITY4"
-       30000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "TRA_COMMODITY4")
-    #s(item$
-       TRA_COMMODITY5
-       "TRA_COMMODITY5"
-       50000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "TRA_COMMODITY5")
-    #s(item$
-       TRA_COMPONENT1
-       "TRA_COMPONENT1"
-       1000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "TRA_COMPONENT1")
-    #s(item$
-       TRA_COMPONENT2
-       "TRA_COMPONENT2"
-       6000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "TRA_COMPONENT2")
-    #s(item$
-       TRA_COMPONENT3
-       "TRA_COMPONENT3"
-       15000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "TRA_COMPONENT3")
-    #s(item$
-       TRA_COMPONENT4
-       "TRA_COMPONENT4"
-       30000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "TRA_COMPONENT4")
-    #s(item$
-       TRA_COMPONENT5
-       "TRA_COMPONENT5"
-       50000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "TRA_COMPONENT5")
-    #s(item$
-       Table
-       "BUILDTABLE"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Table")
-    #s(item$
-       Tall-Cabinet
-       "BUILDHCABINET"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Tall Cabinet")
-    #s(item$
-       Tamper-Prevention-Device
-       "MAINT_TECH10"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Tamper Prevention Device")
-    #s(item$
-       Tech-Panel
-       "TECHPANEL"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Tech Panel")
-    #s(item$
-       Technology-Module
-       "TECH_COMP"
-       50000
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Technology Module")
-    #s(item$
-       Teleport-Receiver
-       "SHIP_TELEPORT"
-       1
-       (Technology:Ship TechnologyRarity:VeryRare TechShopRarity:Common)
-       "Teleport Receiver")
-    #s(item$
-       Terrain-Manipulator
-       "TERRAINEDITOR"
-       1
-       (Technology:Weapon TechnologyRarity:Common TechShopRarity:Common)
-       "Terrain Manipulator")
-    #s(item$
-       Tethys-Beam
-       "SUB_LASER"
-       1
-       (Technology:Submarine
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Tethys Beam")
-    #s(item$
-       TetraCobalt
-       "CAVEPROD3"
-       6150
-       (Substance:Exotic Rarity:Rare Product:Curiousity)
-       "TetraCobalt")
-    #s(item$
-       |Thermal-Protection-Module-(A)|
-       "U_COLDPROT2"
-       240
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Thermal Protection Module (A)")
-    #s(item$
-       |Thermal-Protection-Module-(A)|
-       "U_HOTPROT2"
-       240
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Thermal Protection Module (A)")
-    #s(item$
-       |Thermal-Protection-Module-(B)|
-       "U_COLDPROT1"
-       140
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Thermal Protection Module (B)")
-    #s(item$
-       |Thermal-Protection-Module-(B)|
-       "U_HOTPROT1"
-       140
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Thermal Protection Module (B)")
-    #s(item$
-       |Thermal-Protection-Module-(S)|
-       "U_COLDPROT3"
-       360
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Thermal Protection Module (S)")
-    #s(item$
-       |Thermal-Protection-Module-(S)|
-       "U_HOTPROT3"
-       360
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Thermal Protection Module (S)")
-    #s(item$
-       Thermic-Condensate
-       "REACTION1"
-       50000
-       (Substance:Special Rarity:Rare Product:Tradeable)
-       "Thermic Condensate")
-    #s(item$
-       Thermoregulator
-       "MAINT_TECH13"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Thermoregulator")
-    #s(item$
-       Thin-Concrete-Wall
-       "C_WALL_H"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Thin Concrete Wall")
-    #s(item$
-       Thin-Metal-Wall
-       "M_WALL_H"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Thin Metal Wall")
-    #s(item$
-       Thin-Wooden-Wall
-       "W_WALL_H"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Thin Wooden Wall")
-    #s(item$
-       Tiny-motor
-       "MAINT_TECH7"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Tiny motor")
-    #s(item$
-       Tower-Module
-       "BUILDTOWER"
-       2
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Tower Module")
-    #s(item$
-       |Toxic-Protection-Module-(A)|
-       "U_TOX2"
-       240
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Toxic Protection Module (A)")
-    #s(item$
-       |Toxic-Protection-Module-(B)|
-       "U_TOX1"
-       140
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Toxic Protection Module (B)")
-    #s(item$
-       |Toxic-Protection-Module-(S)|
-       "U_TOX3"
-       360
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Toxic Protection Module (S)")
-    #s(item$
-       Transmission-Box
-       "MAINT_TECH25"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Transmission Box")
-    #s(item$
-       Trident-Key
-       "TRIDENT_KEY"
-       1000
-       (Substance:Special Rarity:Rare Product:Curiousity)
-       "Trident Key")
-    #s(item$
-       Trident-Key
-       "MAINT_SEALOCK2"
-       1
-       (Technology:Maintenance
-        TechnologyRarity:Impossible
-        TechShopRarity:Impossible)
-       "Trident Key")
-    #s(item$ Tritium "ROCKETSUB" 6 (Rarity:Common) "Tritium")
-    #s(item$
-       |Underwater-Protection-Module-(A)|
-       "U_UNW2"
-       240
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Underwater Protection Module (A)")
-    #s(item$
-       |Underwater-Protection-Module-(B)|
-       "U_UNW1"
-       140
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Underwater Protection Module (B)")
-    #s(item$
-       |Underwater-Protection-Module-(S)|
-       "U_UNW3"
-       360
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Underwater Protection Module (S)")
-    #s(item$
-       Unrefined-Pyrite-Grease
-       "TRA_MINERALS2"
-       6000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "Unrefined Pyrite Grease")
-    #s(item$
-       Unstable-Gel
-       "FARMPROD6"
-       50000
-       (Substance:Special Rarity:Rare Product:Tradeable)
-       "Unstable Gel")
-    #s(item$
-       Unstable-Plasma
-       "GRENFUEL1"
-       5750
-       (Substance:Fuel Rarity:Rare Product:Consumable)
-       "Unstable Plasma")
-    #s(item$
-       Upgrade-Module
-       "T_SHIPJUMP"
-       1
-       (Technology:Ship TechnologyRarity:Impossible TechShopRarity:Impossible)
-       "Upgrade Module")
-    #s(item$ Uranium "RADIO1" 62 (Rarity:Uncommon) "Uranium")
-    #s(item$
-       Venom-Urchin
-       "SACVENOMPLANT"
-       3
-       (Substance:BuildingPart Rarity:Rare Product:BuildingPart)
-       "Venom Urchin")
-    #s(item$
-       Vertical-Glass-Tunnel
-       "CORRIDORV_WATER"
-       3
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Vertical Glass Tunnel")
-    #s(item$
-       Viewing-Sphere
-       "VIEWSPHERE"
-       10
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Viewing Sphere")
-    #s(item$ Viscous-Fluids "SPACEGUNK5" 20 (Rarity:Rare) "Viscous Fluids")
-    #s(item$
-       Vortex-Cube
-       "CAVECUBE"
-       5800
-       (Substance:Exotic Rarity:Rare Product:Tradeable)
-       "Vortex Cube")
-    #s(item$
-       |Vy'keen-Dagger|
-       "WAR_CURIO2"
-       11688
-       (Substance:Exotic Rarity:Common Product:Curiousity)
-       "Vy'keen Dagger")
-    #s(item$
-       |Vy'keen-Effigy|
-       "WAR_CURIO1"
-       24750
-       (Substance:Exotic Rarity:Rare Product:Curiousity)
-       "Vy'keen Effigy")
-    #s(item$
-       Walker-Brain
-       "WALKER_PROD"
-       35000
-       (Substance:Special Rarity:Rare Product:Component)
-       "Walker Brain")
-    #s(item$
-       Wall
-       "WALL"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Wall")
-    #s(item$
-       Wall-Fan
-       "WALLFAN"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Wall Fan")
-    #s(item$
-       Wall-Flag
-       "WALLFLAG1"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Wall Flag")
-    #s(item$
-       Wall-Screen
-       "WALLSCREEN"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Wall Screen")
-    #s(item$
-       Wall-Unit
-       "BLDWALLUNIT"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Wall Unit")
-    #s(item$
-       Warp-Cell
-       "HYPERFUEL1"
-       46750
-       (Substance:Special Rarity:Rare Product:Consumable)
-       "Warp Cell")
-    #s(item$
-       Warp-Shielding-Sigma
-       "F_HACCESS1"
-       1
-       (Technology:Freighter TechnologyRarity:Impossible TechShopRarity:Normal)
-       "Warp Shielding Sigma")
-    #s(item$
-       Warp-Shielding-Tau
-       "F_HACCESS2"
-       1
-       (Technology:Freighter TechnologyRarity:Impossible TechShopRarity:Rare)
-       "Warp Shielding Tau")
-    #s(item$
-       Warp-Shielding-Theta
-       "F_HACCESS3"
-       1
-       (Technology:Freighter TechnologyRarity:Impossible TechShopRarity:Rare)
-       "Warp Shielding Theta")
-    #s(item$
-       Watertight-Door
-       "BUILDDOOR_WATER"
-       2
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Watertight Door")
-    #s(item$
-       Waveform-Recycler
-       "UT_SCAN"
-       1
-       (Technology:Weapon TechnologyRarity:Common TechShopRarity:Common)
-       "Waveform Recycler")
-    #s(item$
-       Weapon-Rack
-       "WEAPONRACK"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Weapon Rack")
-    #s(item$
-       Weapons-Terminal
-       "NPCWEAPONTERM"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Weapons Terminal")
-    #s(item$
-       Welding-Soap
-       "TRA_TECH2"
-       6000
-       (Substance:Exotic Rarity:Common Product:Tradeable)
-       "Welding Soap")
-    #s(item$
-       Window
-       "BUILDWINDOW"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Window")
-    #s(item$
-       Wonder
-       "SPEC_EMOTE04"
-       1500
-       (Substance:Exotic Rarity:Common Product:Emote)
-       "Wonder")
-    #s(item$
-       Wood-Floor-Panel
-       "W_FLOOR"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Wood Floor Panel")
-    #s(item$
-       Wood=Framed-Glass-Panel
-       "W_GFLOOR"
-       3
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Wood-Framed Glass Panel")
-    #s(item$
-       Wooden-Arch
-       "W_ARCH"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Wooden Arch")
-    #s(item$
-       Wooden-Door-Frame
-       "W_DOOR"
-       2
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Wooden Door Frame")
-    #s(item$
-       Wooden-Doorway
-       "W_DOOR_H"
-       2
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Wooden Doorway")
-    #s(item$
-       Wooden-Frontage
-       "W_DOORWINDOW"
-       2
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Wooden Frontage")
-    #s(item$
-       Wooden-Half-Arch
-       "W_ARCH_H"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Wooden Half Arch")
-    #s(item$
-       Wooden-Half-Ramp
-       "W_RAMP_H"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Wooden Half Ramp")
-    #s(item$
-       Wooden-Ramp
-       "W_RAMP"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Wooden Ramp")
-    #s(item$
-       Wooden-Roof
-       "W_ROOF"
-       2
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Wooden Roof")
-    #s(item$
-       Wooden-Roof-Corner
-       "W_ROOF_C"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Wooden Roof Corner")
-    #s(item$
-       Wooden-Roof-Panel
-       "W_ROOF_M"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Wooden Roof Panel")
-    #s(item$
-       Wooden-Wall
-       "W_WALL"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Wooden Wall")
-    #s(item$
-       Wooden-Window-Panel
-       "W_WALL_WINDOW"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Wooden Window Panel")
-    #s(item$
-       Worktop
-       "BUILDWORKTOP"
-       1
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "Worktop")
-    #s(item$
-       X.O.-Suit
-       "SPEC_XOHELMET"
-       1000
-       (Substance:Exotic Rarity:Common Product:Consumable)
-       "X.O. Suit")
-    #s(item$
-       X=Shaped-Corridor
-       "CORRIDORX"
-       5
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "X-Shaped Corridor")
-    #s(item$
-       X=Shaped-Glass-Tunnel
-       "CORRIDORX_WATER"
-       3
-       (Substance:BuildingPart Rarity:Common Product:BuildingPart)
-       "X-Shaped Glass Tunnel")))
-(for ((item generated-items)) (add-item item))
+  #hash(("OCTACABINET"
+         .
+         #s(item$
+            Octa=Cabinet
+            "OCTACABINET"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Octa-Cabinet"))
+        ("REACTION1"
+         .
+         #s(item$
+            Thermic-Condensate
+            "REACTION1"
+            50000
+            (Substance:Special Rarity:Rare Product:Tradeable)
+            "Thermic Condensate"))
+        ("MAINROOMCUBE_W"
+         .
+         #s(item$
+            Square-Deepwater-Chamber
+            "MAINROOMCUBE_W"
+            6
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Square Deepwater Chamber"))
+        ("NANOTUBES"
+         .
+         #s(item$
+            Carbon-Nanotubes
+            "NANOTUBES"
+            500
+            (Substance:Catalyst Rarity:Common Product:Component)
+            "Carbon Nanotubes"))
+        ("ROBOTICARM"
+         .
+         #s(item$
+            Robotic-Arm
+            "ROBOTICARM"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Robotic Arm"))
+        ("EYEBALL"
+         .
+         #s(item$
+            Hypnotic-Eye
+            "EYEBALL"
+            60000
+            (Substance:Exotic Rarity:Rare Product:Tradeable)
+            "Hypnotic Eye"))
+        ("BUILDDECAL"
+         .
+         #s(item$
+            Decal
+            "BUILDDECAL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Decal"))
+        ("CORRIDOR_SPACE"
+         .
+         #s(item$
+            Freighter-Corridor
+            "CORRIDOR_SPACE"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Freighter Corridor"))
+        ("BIOROOM"
+         .
+         #s(item$
+            Bio=Dome
+            "BIOROOM"
+            10
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Bio-Dome"))
+        ("BUILDLOCKER"
+         .
+         #s(item$
+            Locker
+            "BUILDLOCKER"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Locker"))
+        ("VEHICLE_ENGINE"
+         .
+         #s(item$
+            Fusion-Engine
+            "VEHICLE_ENGINE"
+            1
+            (Technology:Exocraft
+             TechnologyRarity:Always
+             TechShopRarity:Impossible)
+            "Fusion Engine"))
+        ("MAINT_SEALOCK1"
+         .
+         #s(item$
+            Pearl-Offering
+            "MAINT_SEALOCK1"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Pearl Offering"))
+        ("PLANTPOT1"
+         .
+         #s(item$
+            Flora-Containment
+            "PLANTPOT1"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Flora Containment"))
+        ("T_BOLT"
+         .
+         #s(item$
+            Upgrade-Module
+            "T_SHIPJUMP"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Upgrade Module"))
+        ("M_WALL_H"
+         .
+         #s(item$
+            Thin-Metal-Wall
+            "M_WALL_H"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Thin Metal Wall"))
+        ("WALLLIGHTPINK"
+         .
+         #s(item$
+            Coloured-Light
+            "WALLLIGHTBLUE"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Coloured Light"))
+        ("BUILDDECALSIMP3"
+         .
+         #s(item$
+            Decal
+            "BUILDDECAL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Decal"))
+        ("U_COLDPROT3"
+         .
+         #s(item$
+            |Thermal-Protection-Module-(S)|
+            "U_COLDPROT3"
+            360
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Thermal Protection Module (S)"))
+        ("ANTIMATTER"
+         .
+         #s(item$
+            Antimatter
+            "ANTIMATTER"
+            5233
+            (Substance:Special Rarity:Rare Product:Component)
+            "Antimatter"))
+        ("BASE_MEDPLANT02"
+         .
+         #s(item$
+            Dwarf-Palm
+            "BASE_MEDPLANT02"
+            500
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Dwarf Palm"))
+        ("ACCESS1"
+         .
+         #s(item$
+            AtlasPass-v1
+            "ACCESS1"
+            825
+            (Substance:Stellar Rarity:Common Product:Curiousity)
+            "AtlasPass v1"))
+        ("U_BOLT3"
+         .
+         #s(item$
+            |Boltcaster-Module-(A)|
+            "U_BOLT3"
+            240
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Boltcaster Module (A)"))
+        ("LAND3"
+         .
+         #s(item$
+            Magnetised-Ferrite
+            "LAND3"
+            82
+            (Rarity:Uncommon)
+            "Magnetised Ferrite"))
+        ("FIENDCORE"
+         .
+         #s(item$
+            Larval-Core
+            "FIENDCORE"
+            65000
+            (Substance:Exotic Rarity:Rare Product:Curiousity)
+            "Larval Core"))
+        ("BASE_TOYSPHERE"
+         .
+         #s(item$
+            Holographic-Globe-Gadget
+            "BASE_TOYSPHERE"
+            800
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Holographic Globe Gadget"))
+        ("FUEL2"
+         .
+         #s(item$
+            Condensed-Carbon
+            "FUEL2"
+            24
+            (Rarity:Uncommon)
+            "Condensed Carbon"))
+        ("C_GFLOOR"
+         .
+         #s(item$
+            Concrete=Framed-Glass-Panel
+            "C_GFLOOR"
+            3
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Concrete-Framed Glass Panel"))
+        ("MAINT_PORTAL13"
+         .
+         #s(item$
+            Portal-Glyph
+            "MAINT_PORTAL1"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Portal Glyph"))
+        ("STATUE_ASTRO_G"
+         .
+         #s(item$
+            Gold-Astronaut-Statue
+            "STATUE_ASTRO_G"
+            500
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Gold Astronaut Statue"))
+        ("BUILDDECALSIMP1"
+         .
+         #s(item$
+            Decal
+            "BUILDDECAL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Decal"))
+        ("U_EXO_ENG2"
+         .
+         #s(item$
+            |Exocraft-Engine-Module-(B)|
+            "U_EXO_ENG2"
+            140
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Exocraft Engine Module (B)"))
+        ("ROOMFLOOR"
+         .
+         #s(item$
+            Roof-Platform
+            "ROOMFLOOR"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Roof Platform"))
+        ("O2_HARVESTER"
+         .
+         #s(item$
+            Oxygen-Harvester
+            "O2_HARVESTER"
+            10
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Oxygen Harvester"))
+        ("MAINT_FRIG6"
+         .
+         #s(item$
+            Pressure-Chamber
+            "MAINT_TECH17"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Pressure Chamber"))
+        ("T_SHIELD"
+         .
+         #s(item$
+            Upgrade-Module
+            "T_SHIPJUMP"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Upgrade Module"))
+        ("ATLAS_SEED_9"
+         .
+         #s(item$
+            Modified-Quanta
+            "ATLAS_SEED_9"
+            1000
+            (Substance:Stellar Rarity:Rare Product:Curiousity)
+            "Modified Quanta"))
+        ("C_DOOR"
+         .
+         #s(item$
+            Concrete-Door-Frame
+            "C_DOOR"
+            2
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Concrete Door Frame"))
+        ("CREATHOLOGRAM"
+         .
+         #s(item$
+            Creature-Hologram
+            "CREATHOLOGRAM"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Creature Hologram"))
+        ("MAINT_PORTAL8"
+         .
+         #s(item$
+            Portal-Glyph
+            "MAINT_PORTAL1"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Portal Glyph"))
+        ("C_WALL"
+         .
+         #s(item$
+            Concrete-Wall
+            "C_WALL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Concrete Wall"))
+        ("UT_WATERJET"
+         .
+         #s(item$
+            Efficient-Water-Jets
+            "UT_WATERJET"
+            1
+            (Technology:Suit TechnologyRarity:Common TechShopRarity:Common)
+            "Efficient Water Jets"))
+        ("U_SHIPGUN2"
+         .
+         #s(item$
+            |Photon-Cannon-Module-(B)|
+            "U_SHIPGUN2"
+            140
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Photon Cannon Module (B)"))
+        ("U_SHIPBLOB4"
+         .
+         #s(item$
+            |Cyclotron-Module-(S)|
+            "U_SHIPBLOB4"
+            360
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Cyclotron Module (S)"))
+        ("SHIPSLOT_DMG1"
+         .
+         #s(item$
+            Hull-Fracture
+            "SHIPSLOT_DMG1"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Hull Fracture"))
+        ("FISHCORE"
+         .
+         #s(item$
+            Hadal-Core
+            "FISHCORE"
+            97500
+            (Substance:Exotic Rarity:Rare Product:Tradeable)
+            "Hadal Core"))
+        ("MAINROOMCUBE"
+         .
+         #s(item$
+            Square-Room
+            "MAINROOMCUBE"
+            3
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Square Room"))
+        ("U_EXO_SUBGUN1"
+         .
+         #s(item$
+            |Nautilon-Cannon-Module-(C)|
+            "U_EXO_SUBGUN1"
+            60
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Nautilon Cannon Module (C)"))
+        ("U_ENERGY1"
+         .
+         #s(item$
+            |Life-Support-Module-(B)|
+            "U_ENERGY1"
+            140
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Life Support Module (B)"))
+        ("U_PULSE3"
+         .
+         #s(item$
+            |Pulse-Engine-Module-(A)|
+            "U_PULSE3"
+            240
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Pulse Engine Module (A)"))
+        ("COMPOUND5"
+         .
+         #s(item$
+            Superconductor
+            "COMPOUND5"
+            1500000
+            (Substance:Special Rarity:Rare Product:Tradeable)
+            "Superconductor"))
+        ("TRA_MINERALS2"
+         .
+         #s(item$
+            Unrefined-Pyrite-Grease
+            "TRA_MINERALS2"
+            6000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "Unrefined Pyrite Grease"))
+        ("SUBFUEL"
+         .
+         #s(item$
+            Hydrothermal-Fuel-Cell
+            "SUBFUEL"
+            7200
+            (Substance:Fuel Rarity:Uncommon Product:Consumable)
+            "Hydrothermal Fuel Cell"))
+        ("BUILDDECALNUM0"
+         .
+         #s(item$
+            Decal
+            "BUILDDECAL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Decal"))
+        ("U_PULSE2"
+         .
+         #s(item$
+            |Pulse-Engine-Module-(B)|
+            "U_PULSE2"
+            140
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Pulse Engine Module (B)"))
+        ("MIND_ARC"
+         .
+         #s(item$
+            Mind-Arc
+            "MIND_ARC"
+            1000
+            (Substance:Special Rarity:Rare Product:Curiousity)
+            "Mind Arc"))
+        ("T_LASER"
+         .
+         #s(item$
+            Upgrade-Module
+            "T_SHIPJUMP"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Upgrade Module"))
+        ("WALLFLAG1"
+         .
+         #s(item$
+            Wall-Flag
+            "WALLFLAG1"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Wall Flag"))
+        ("PLANTPOT3"
+         .
+         #s(item$
+            Flora-Containment
+            "PLANTPOT1"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Flora Containment"))
+        ("ATLAS_SEED_7"
+         .
+         #s(item$
+            State-Phasure
+            "ATLAS_SEED_7"
+            1000
+            (Substance:Stellar Rarity:Rare Product:Curiousity)
+            "State Phasure"))
+        ("BUILDCHAIR"
+         .
+         #s(item$
+            Chair
+            "BUILDCHAIR"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Chair"))
+        ("EX_RED"
+         .
+         #s(item$
+            Activated-Cadmium
+            "EX_RED"
+            450
+            (Rarity:Rare)
+            "Activated Cadmium"))
+        ("HEALTHSTATION"
+         .
+         #s(item$
+            Health-Station
+            "HEALTHSTATION"
+            5
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Health Station"))
+        ("CRATELCYLINDER"
+         .
+         #s(item$
+            Barrel-Fabricator
+            "CRATELCYLINDER"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Barrel Fabricator"))
+        ("STATUE_ATLAS_G"
+         .
+         #s(item$
+            Gold-Atlas-Statue
+            "STATUE_ATLAS_G"
+            500
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Gold Atlas Statue"))
+        ("BUILDPAVINGTALL"
+         .
+         #s(item$
+            Paving
+            "BUILDPAVING"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Paving"))
+        ("FARMPROD3"
+         .
+         #s(item$
+            Glass
+            "FARMPROD3"
+            13000
+            (Substance:Special Rarity:Rare Product:Tradeable)
+            "Glass"))
+        ("LAUNCHER"
+         .
+         #s(item$
+            Launch-Thruster
+            "LAUNCHER"
+            1
+            (Technology:Ship TechnologyRarity:Always TechShopRarity:Impossible)
+            "Launch Thruster"))
+        ("BUILDDECALVIS4"
+         .
+         #s(item$
+            Decal
+            "BUILDDECAL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Decal"))
+        ("SHIPSLOT_DMG4"
+         .
+         #s(item$
+            Radiation-Leak
+            "SHIPSLOT_DMG4"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Radiation Leak"))
+        ("BUILDBEACON"
+         .
+         #s(item$
+            Beacon
+            "BUILDBEACON"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Beacon"))
+        ("MAINT_ARTIFACT"
+         .
+         #s(item$
+            Ancient-Lock
+            "MAINT_ARTIFACT"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Ancient Lock"))
+        ("BUILDDECALNUM3"
+         .
+         #s(item$
+            Decal
+            "BUILDDECAL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Decal"))
+        ("SPEC_XOHELMET"
+         .
+         #s(item$
+            X.O.-Suit
+            "SPEC_XOHELMET"
+            1000
+            (Substance:Exotic Rarity:Common Product:Consumable)
+            "X.O. Suit"))
+        ("TRA_ENERGY3"
+         .
+         #s(item$
+            Ohmic-Gel
+            "TRA_ENERGY3"
+            15000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "Ohmic Gel"))
+        ("U_EXOGUN3"
+         .
+         #s(item$
+            |Exocraft-Cannon-Module-(A)|
+            "U_EXOGUN3"
+            240
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Exocraft Cannon Module (A)"))
+        ("U_SHIPLAS2"
+         .
+         #s(item$
+            |Phase-Beam-Module-(B)|
+            "U_SHIPLAS2"
+            140
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Phase Beam Module (B)"))
+        ("U_JETBOOST4"
+         .
+         #s(item$
+            |Movement-Module-(S)|
+            "U_JETBOOST4"
+            360
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Movement Module (S)"))
+        ("M_WALL_Q"
+         .
+         #s(item$
+            Small-Metal-Wall
+            "M_WALL_Q"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Small Metal Wall"))
+        ("CUBEFRAME"
+         .
+         #s(item$
+            Cuboid-Room-Frame
+            "CUBEFRAME"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Cuboid Room Frame"))
+        ("CEILINGLIGHT"
+         .
+         #s(item$
+            Ceiling-Light
+            "CEILINGLIGHT"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Ceiling Light"))
+        ("EX_BLUE"
+         .
+         #s(item$
+            Activated-Indium
+            "EX_BLUE"
+            949
+            (Rarity:Rare)
+            "Activated Indium"))
+        ("MAINT_FUEL5"
+         .
+         #s(item$
+            Kinetic-Dynamo
+            "MAINT_FUEL5"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Kinetic Dynamo"))
+        ("SHIPSHIELD"
+         .
+         #s(item$
+            Deflector-Shield
+            "SHIPSHIELD"
+            1
+            (Technology:Ship TechnologyRarity:Always TechShopRarity:Impossible)
+            "Deflector Shield"))
+        ("U_RAIL3"
+         .
+         #s(item$
+            |Blaze-Javelin-Module-(A)|
+            "U_RAIL3"
+            240
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Blaze Javelin Module (A)"))
+        ("U_SHIELDBOOST4"
+         .
+         #s(item$
+            |Shield-Module-(S)|
+            "U_SHIELDBOOST4"
+            360
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Shield Module (S)"))
+        ("STATUE_ATLAS_B"
+         .
+         #s(item$
+            Bronze-Atlas-Statue
+            "STATUE_ATLAS_B"
+            300
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Bronze Atlas Statue"))
+        ("MAINT_PORTAL2"
+         .
+         #s(item$
+            Portal-Glyph
+            "MAINT_PORTAL1"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Portal Glyph"))
+        ("CAVEPROD3"
+         .
+         #s(item$
+            TetraCobalt
+            "CAVEPROD3"
+            6150
+            (Substance:Exotic Rarity:Rare Product:Curiousity)
+            "TetraCobalt"))
+        ("TOXICPLANT"
+         .
+         #s(item$
+            Fungal-Cluster
+            "TOXICPLANT"
+            3
+            (Substance:BuildingPart Rarity:Rare Product:BuildingPart)
+            "Fungal Cluster"))
+        ("SPEC_DECAL02"
+         .
+         #s(item$
+            Galactic-Hub-Decal
+            "SPEC_DECAL02"
+            400
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Galactic Hub Decal"))
+        ("GRAVPLANT"
+         .
+         #s(item$
+            Gravitino-Host
+            "GRAVPLANT"
+            3
+            (Substance:BuildingPart Rarity:Rare Product:BuildingPart)
+            "Gravitino Host"))
+        ("MAINT_TECH4"
+         .
+         #s(item$
+            Input-terminal
+            "MAINT_TECH4"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Input terminal"))
+        ("DOOR2"
+         .
+         #s(item$
+            Holo=Door
+            "DOOR2"
+            8
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Holo-Door"))
+        ("PHOTONIX_CORE"
+         .
+         #s(item$
+            Photonix-Core
+            "PHOTONIX_CORE"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Photonix Core"))
+        ("UT_PROTECT"
+         .
+         #s(item$
+            Shield-Lattice
+            "UT_PROTECT"
+            1
+            (Technology:Suit TechnologyRarity:Common TechShopRarity:Common)
+            "Shield Lattice"))
+        ("ALLOY4"
+         .
+         #s(item$
+            Lemmium
+            "ALLOY4"
+            25000
+            (Substance:Stellar Rarity:Rare Product:Tradeable)
+            "Lemmium"))
+        ("CORRIDORT_SPACE"
+         .
+         #s(item$
+            Freighter-Junction
+            "CORRIDORT_SPACE"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Freighter Junction"))
+        ("VEHICLE_BOOST"
+         .
+         #s(item$
+            Exocraft-Acceleration-Module
+            "VEHICLE_BOOST"
+            1
+            (Technology:Exocraft
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Exocraft Acceleration Module"))
+        ("U_HYPER1"
+         .
+         #s(item$
+            |Hyperdrive-Module-(C)|
+            "U_HYPER1"
+            60
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Hyperdrive Module (C)"))
+        ("CUBEFOUND4"
+         .
+         #s(item$
+            Cuboid-Room-Foundation-Strut-Quad
+            "CUBEFOUND4"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Cuboid Room Foundation Strut Quad"))
+        ("MAINT_PORTAL14"
+         .
+         #s(item$
+            Portal-Glyph
+            "MAINT_PORTAL1"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Portal Glyph"))
+        ("U_EXOBOOST1"
+         .
+         #s(item$
+            |Exocraft-Boost-Module-(C)|
+            "U_EXOBOOST1"
+            60
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Exocraft Boost Module (C)"))
+        ("U_SHIPSHIELD4"
+         .
+         #s(item$
+            |Starship-Shield-Module-(S)|
+            "U_SHIPSHIELD4"
+            360
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Starship Shield Module (S)"))
+        ("CORRIDOR_WATER"
+         .
+         #s(item$
+            Glass-Tunnel
+            "CORRIDOR_WATER"
+            3
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Glass Tunnel"))
+        ("W_DOOR_H"
+         .
+         #s(item$
+            Wooden-Doorway
+            "W_DOOR_H"
+            2
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Wooden Doorway"))
+        ("CUBEROOMB_SPACE"
+         .
+         #s(item$
+            Large-Freighter-Room
+            "CUBEROOM_SPACE"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Large Freighter Room"))
+        ("U_EXOGUN4"
+         .
+         #s(item$
+            |Exocraft-Cannon-Module-(S)|
+            "U_EXOGUN4"
+            360
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Exocraft Cannon Module (S)"))
+        ("WALLFLOORLADDER"
+         .
+         #s(item$
+            Infrastructure-Ladder
+            "WALLFLOORLADDER"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Infrastructure Ladder"))
+        ("PLANT_POOP"
+         .
+         #s(item$ Coprite "PLANT_POOP" 30 (Rarity:Common) "Coprite"))
+        ("ROCKETSUB"
+         .
+         #s(item$ Tritium "ROCKETSUB" 6 (Rarity:Common) "Tritium"))
+        ("STATUE_WALK_B"
+         .
+         #s(item$
+            Bronze-Walker-Statue
+            "STATUE_WALK_B"
+            300
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Bronze Walker Statue"))
+        ("SCANBINOC1"
+         .
+         #s(item$
+            Analysis-Visor
+            "SCANBINOC1"
+            1
+            (Technology:Weapon
+             TechnologyRarity:Always
+             TechShopRarity:Impossible)
+            "Analysis Visor"))
+        ("BUILDDECALNUM4"
+         .
+         #s(item$
+            Decal
+            "BUILDDECAL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Decal"))
+        ("MAINT_PORTAL5"
+         .
+         #s(item$
+            Portal-Glyph
+            "MAINT_PORTAL1"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Portal Glyph"))
+        ("UT_SHOT"
+         .
+         #s(item$
+            Shell-Greaser
+            "UT_SHOT"
+            1
+            (Technology:Weapon TechnologyRarity:Common TechShopRarity:Common)
+            "Shell Greaser"))
+        ("MAINT_TECH8"
+         .
+         #s(item$
+            Cooling-system
+            "MAINT_TECH8"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Cooling system"))
+        ("CARBONPLANTER"
+         .
+         #s(item$
+            Standing-Planter
+            "CARBONPLANTER"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Standing Planter"))
+        ("U_HOTPROT3"
+         .
+         #s(item$
+            |Thermal-Protection-Module-(S)|
+            "U_HOTPROT3"
+            360
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Thermal Protection Module (S)"))
+        ("DRESSING_TABLE"
+         .
+         #s(item$
+            Appearance-Modifier
+            "DRESSING_TABLE"
+            10
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Appearance Modifier"))
+        ("CONTAINER8"
+         .
+         #s(item$
+            Storage-Container
+            "CONTAINER0"
+            5
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Storage Container"))
+        ("PLANT_DUST"
+         .
+         #s(item$ Cactus-Flesh "PLANT_DUST" 28 (Rarity:Rare) "Cactus Flesh"))
+        ("CUBESHAPE"
+         .
+         #s(item$
+            Cube
+            "CUBESHAPE"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Cube"))
+        ("CAVE1" . #s(item$ Cobalt "CAVE1" 198 (Rarity:Common) "Cobalt"))
+        ("CUBEROOM"
+         .
+         #s(item$
+            Cuboid-Room
+            "CUBEROOM"
+            2
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Cuboid Room"))
+        ("TRA_TECH4"
+         .
+         #s(item$
+            Autonomous-Positioning-Unit
+            "TRA_TECH4"
+            30000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "Autonomous Positioning Unit"))
+        ("HDRIVEBOOST1"
+         .
+         #s(item$
+            Cadmium-Drive
+            "HDRIVEBOOST1"
+            1
+            (Technology:Ship TechnologyRarity:VeryRare TechShopRarity:Common)
+            "Cadmium Drive"))
+        ("C_ARCH"
+         .
+         #s(item$
+            Concrete-Arch
+            "C_ARCH"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Concrete Arch"))
+        ("PLANTER"
+         .
+         #s(item$
+            Hydroponic-Tray
+            "PLANTER"
+            3
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Hydroponic Tray"))
+        ("VENTGEM"
+         .
+         #s(item$
+            Crystal-Sulphide
+            "VENTGEM"
+            7800
+            (Substance:Exotic Rarity:Rare Product:Tradeable)
+            "Crystal Sulphide"))
+        ("WEAPSLOT_DMG3"
+         .
+         #s(item$
+            Damaged-Wiring
+            "WEAPSLOT_DMG3"
+            1
+            (Technology:Weapon
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Damaged Wiring"))
+        ("C_SDOOR"
+         .
+         #s(item$
+            Small-Concrete-Door
+            "C_SDOOR"
+            2
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Small Concrete Door"))
+        ("CUBEROOF"
+         .
+         #s(item$
+            Cuboid-Roof-Cap
+            "CUBEROOF"
+            2
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Cuboid Roof Cap"))
+        ("C_WALL_H"
+         .
+         #s(item$
+            Thin-Concrete-Wall
+            "C_WALL_H"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Thin Concrete Wall"))
+        ("WALKER_PROD"
+         .
+         #s(item$
+            Walker-Brain
+            "WALKER_PROD"
+            35000
+            (Substance:Special Rarity:Rare Product:Component)
+            "Walker Brain"))
+        ("UT_LAUNCHER"
+         .
+         #s(item$
+            Efficient-Thrusters
+            "UT_LAUNCHER"
+            1
+            (Technology:Ship TechnologyRarity:Normal TechShopRarity:Common)
+            "Efficient Thrusters"))
+        ("SERVERSTACK"
+         .
+         #s(item$
+            Server
+            "SERVERSTACK"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Server"))
+        ("M_GFLOOR"
+         .
+         #s(item$
+            Metal=Framed-Glass-Panel
+            "M_GFLOOR"
+            3
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Metal-Framed Glass Panel"))
+        ("STATUE_BLOB_G"
+         .
+         #s(item$
+            Gold-Blob-Statue
+            "STATUE_BLOB_G"
+            500
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Gold Blob Statue"))
+        ("C_RAMP_H"
+         .
+         #s(item$
+            Concrete-Half-Ramp
+            "C_RAMP_H"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Concrete Half Ramp"))
+        ("BUILDDOOR_WATER"
+         .
+         #s(item$
+            Watertight-Door
+            "BUILDDOOR_WATER"
+            2
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Watertight Door"))
+        ("GARAGE_M"
+         .
+         #s(item$
+            Roamer-Geobay
+            "GARAGE_M"
+            10
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Roamer Geobay"))
+        ("U_LASER4"
+         .
+         #s(item$
+            |Mining-Beam-Module-(S)|
+            "U_LASER4"
+            360
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Mining Beam Module (S)"))
+        ("STATUE_BLOB_B"
+         .
+         #s(item$
+            Bronze-Blob-Statue
+            "STATUE_BLOB_B"
+            300
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Bronze Blob Statue"))
+        ("BUILDHCABINET"
+         .
+         #s(item$
+            Tall-Cabinet
+            "BUILDHCABINET"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Tall Cabinet"))
+        ("SPEC_VYK_GLOVES"
+         .
+         #s(item$
+            Armoured-ExoGloves
+            "SPEC_VYK_GLOVES"
+            1000
+            (Substance:Exotic Rarity:Common Product:CustomisationPart)
+            "Armoured ExoGloves"))
+        ("FARMPROD1"
+         .
+         #s(item$
+            Acid
+            "FARMPROD1"
+            188000
+            (Substance:Special Rarity:Rare Product:Tradeable)
+            "Acid"))
+        ("CONTAINER3"
+         .
+         #s(item$
+            Storage-Container
+            "CONTAINER0"
+            5
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Storage Container"))
+        ("TRA_TECH5"
+         .
+         #s(item$
+            Quantum-Accelerator
+            "TRA_TECH5"
+            50000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "Quantum Accelerator"))
+        ("W_DOOR"
+         .
+         #s(item$
+            Wooden-Door-Frame
+            "W_DOOR"
+            2
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Wooden Door Frame"))
+        ("ALLOY5"
+         .
+         #s(item$
+            Magno=Gold
+            "ALLOY5"
+            25000
+            (Substance:Stellar Rarity:Rare Product:Tradeable)
+            "Magno-Gold"))
+        ("SHIPPLASMA"
+         .
+         #s(item$
+            Cyclotron-Ballista
+            "SHIPPLASMA"
+            1
+            (Technology:Ship TechnologyRarity:Impossible TechShopRarity:Normal)
+            "Cyclotron Ballista"))
+        ("ATLAS_SEED_10"
+         .
+         #s(item$
+            Heart-of-the-Sun
+            "ATLAS_SEED_10"
+            1000
+            (Substance:Stellar Rarity:Rare Product:Curiousity)
+            "Heart of the Sun"))
+        ("BUILDDOOR"
+         .
+         #s(item$
+            Door
+            "BUILDDOOR"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Door"))
+        ("RACE_RAMP"
+         .
+         #s(item$
+            Race-Obstacle
+            "RACE_RAMP"
+            10
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Race Obstacle"))
+        ("ATLAS_SEED_4"
+         .
+         #s(item$
+            Dark-Matter
+            "ATLAS_SEED_4"
+            1000
+            (Substance:Stellar Rarity:Rare Product:Curiousity)
+            "Dark Matter"))
+        ("U_TGRENADE2"
+         .
+         #s(item$
+            |Geology-Cannon-Module-(B)|
+            "U_TGRENADE2"
+            140
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Geology Cannon Module (B)"))
+        ("W_GFLOOR"
+         .
+         #s(item$
+            Wood=Framed-Glass-Panel
+            "W_GFLOOR"
+            3
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Wood-Framed Glass Panel"))
+        ("WALLLIGHTRED"
+         .
+         #s(item$
+            Coloured-Light
+            "WALLLIGHTBLUE"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Coloured Light"))
+        ("FOUNDLEG"
+         .
+         #s(item$
+            Foundation-Strut
+            "FOUNDLEG"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Foundation Strut"))
+        ("U_ENERGY3"
+         .
+         #s(item$
+            |Life-Support-Module-(S)|
+            "U_ENERGY3"
+            360
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Life Support Module (S)"))
+        ("U_TOX1"
+         .
+         #s(item$
+            |Toxic-Protection-Module-(B)|
+            "U_TOX1"
+            140
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Toxic Protection Module (B)"))
+        ("CORRIDOR"
+         .
+         #s(item$
+            Straight-Corridor
+            "CORRIDOR"
+            5
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Straight Corridor"))
+        ("POOPPLANT"
+         .
+         #s(item$
+            Coprite-Flower
+            "POOPPLANT"
+            3
+            (Substance:BuildingPart Rarity:Rare Product:BuildingPart)
+            "Coprite Flower"))
+        ("MAINT_PORTAL7"
+         .
+         #s(item$
+            Portal-Glyph
+            "MAINT_PORTAL1"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Portal Glyph"))
+        ("UT_SHIPBLOB"
+         .
+         #s(item$
+            Dyson-Pump
+            "UT_SHIPBLOB"
+            1
+            (Technology:Ship TechnologyRarity:Impossible TechShopRarity:Common)
+            "Dyson Pump"))
+        ("UT_SHIPGUN"
+         .
+         #s(item$
+            Nonlinear-Optics
+            "UT_SHIPGUN"
+            1
+            (Technology:Ship TechnologyRarity:Rare TechShopRarity:Common)
+            "Nonlinear Optics"))
+        ("TRA_EXOTICS1"
+         .
+         #s(item$
+            De=Scented-Pheromone-Bottle
+            "TRA_EXOTICS1"
+            1000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "De-Scented Pheromone Bottle"))
+        ("M_ARCH"
+         .
+         #s(item$
+            Metal-Arch
+            "M_ARCH"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Metal Arch"))
+        ("STATUE_GEK_S"
+         .
+         #s(item$
+            Silver-Gek-Statue
+            "STATUE_GEK_S"
+            400
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Silver Gek Statue"))
+        ("U_BOLT4"
+         .
+         #s(item$
+            |Boltcaster-Module-(S)|
+            "U_BOLT4"
+            360
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Boltcaster Module (S)"))
+        ("BUILD_REFINER2"
+         .
+         #s(item$
+            Medium-Refiner
+            "BUILD_REFINER2"
+            10
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Medium Refiner"))
+        ("SHELFPANEL"
+         .
+         #s(item$
+            Shelf-Panel
+            "SHELFPANEL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Shelf Panel"))
+        ("BUILDLIGHT3"
+         .
+         #s(item$
+            Light
+            "SMALLLIGHT"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Light"))
+        ("ASTEROID1"
+         .
+         #s(item$ Silver "ASTEROID1" 101 (Rarity:Common) "Silver"))
+        ("U_BOLT2"
+         .
+         #s(item$
+            |Boltcaster-Module-(B)|
+            "U_BOLT2"
+            140
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Boltcaster Module (B)"))
+        ("CURVEDCUBEROOF"
+         .
+         #s(item$
+            Curved-Cuboid-Roof
+            "CURVEDCUBEROOF"
+            3
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Curved Cuboid Roof"))
+        ("U_SHIPLAS4"
+         .
+         #s(item$
+            |Phase-Beam-Module-(S)|
+            "U_SHIPLAS4"
+            360
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Phase Beam Module (S)"))
+        ("U_RAD3"
+         .
+         #s(item$
+            |Radiation-Protection-Module-(S)|
+            "U_RAD3"
+            360
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Radiation Protection Module (S)"))
+        ("PLANT_HOT"
+         .
+         #s(item$ Solanium "PLANT_HOT" 70 (Rarity:Rare) "Solanium"))
+        ("WEAPONRACK"
+         .
+         #s(item$
+            Weapon-Rack
+            "WEAPONRACK"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Weapon Rack"))
+        ("GLASSCORRIDOR"
+         .
+         #s(item$
+            Glass-Roofed-Corridor
+            "GLASSCORRIDOR"
+            5
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Glass Roofed Corridor"))
+        ("U_SHIPBLOB3"
+         .
+         #s(item$
+            |Cyclotron-Module-(A)|
+            "U_SHIPBLOB3"
+            240
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Cyclotron Module (A)"))
+        ("U_TGRENADE4"
+         .
+         #s(item$
+            |Geology-Cannon-Module-(S)|
+            "U_TGRENADE4"
+            360
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Geology Cannon Module (S)"))
+        ("U_SHIPSHIELD3"
+         .
+         #s(item$
+            |Starship-Shield-Module-(A)|
+            "U_SHIPSHIELD3"
+            240
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Starship Shield Module (A)"))
+        ("U_COLDPROT2"
+         .
+         #s(item$
+            |Thermal-Protection-Module-(A)|
+            "U_COLDPROT2"
+            240
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Thermal Protection Module (A)"))
+        ("WEAPSLOT_DMG5"
+         .
+         #s(item$
+            Corrupt-Module
+            "WEAPSLOT_DMG5"
+            1
+            (Technology:Weapon
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Corrupt Module"))
+        ("BRIDGECONNECTOR"
+         .
+         #s(item$
+            BRIDGECONNECTOR
+            "BRIDGECONNECTOR"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "BRIDGECONNECTOR"))
+        ("BUILDRAMP"
+         .
+         #s(item$
+            Access-Ramp
+            "BUILDRAMP"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Access Ramp"))
+        ("CORRIDORL_WATER"
+         .
+         #s(item$
+            L=Shaped-Glass-Tunnel
+            "CORRIDORL_WATER"
+            3
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "L-Shaped Glass Tunnel"))
+        ("CUBEINNERDOOR"
+         .
+         #s(item$
+            Cuboid-Inner-Door
+            "CUBEINNERDOOR"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Cuboid Inner Door"))
+        ("U_HYPER2"
+         .
+         #s(item$
+            |Hyperdrive-Module-(B)|
+            "U_HYPER2"
+            140
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Hyperdrive Module (B)"))
+        ("MAINT_TECH10"
+         .
+         #s(item$
+            Tamper-Prevention-Device
+            "MAINT_TECH10"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Tamper Prevention Device"))
+        ("CUBELADDER"
+         .
+         #s(item$
+            Cuboid-Room-Ladder
+            "CUBELADDER"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Cuboid Room Ladder"))
+        ("U_COLDPROT1"
+         .
+         #s(item$
+            |Thermal-Protection-Module-(B)|
+            "U_COLDPROT1"
+            140
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Thermal Protection Module (B)"))
+        ("U_SHOTGUN2"
+         .
+         #s(item$
+            |Scatter-Blaster-Module-(B)|
+            "U_SHOTGUN2"
+            140
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Scatter Blaster Module (B)"))
+        ("PYRAMIDSHAPE"
+         .
+         #s(item$
+            Pyramid
+            "PYRAMIDSHAPE"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Pyramid"))
+        ("T_SHIPJUMP"
+         .
+         #s(item$
+            Upgrade-Module
+            "T_SHIPJUMP"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Upgrade Module"))
+        ("CUBEFLOOR"
+         .
+         #s(item$
+            Cuboid-Room-Flooring
+            "CUBEFLOOR"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Cuboid Room Flooring"))
+        ("CORRIDORV_WATER"
+         .
+         #s(item$
+            Vertical-Glass-Tunnel
+            "CORRIDORV_WATER"
+            3
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Vertical Glass Tunnel"))
+        ("GARAGE_L"
+         .
+         #s(item$
+            Colossus-Geobay
+            "GARAGE_L"
+            10
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Colossus Geobay"))
+        ("M_DOORWINDOW"
+         .
+         #s(item$
+            Metal-Frontage
+            "M_DOORWINDOW"
+            3
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Metal Frontage"))
+        ("SPECIAL_POOP"
+         .
+         #s(item$ Hexite "SPECIAL_POOP" 654 (Rarity:Common) "Hexite"))
+        ("U_EXOBOOST3"
+         .
+         #s(item$
+            |Exocraft-Boost-Module-(A)|
+            "U_EXOBOOST3"
+            240
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Exocraft Boost Module (A)"))
+        ("CUBEWINDOW"
+         .
+         #s(item$
+            Window
+            "BUILDWINDOW"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Window"))
+        ("STATUE_GEK_B"
+         .
+         #s(item$
+            Bronze-Gek-Statue
+            "STATUE_GEK_B"
+            300
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Bronze Gek Statue"))
+        ("U_TGRENADE3"
+         .
+         #s(item$
+            |Geology-Cannon-Module-(A)|
+            "U_TGRENADE3"
+            240
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Geology Cannon Module (A)"))
+        ("UT_SHIPSHOT"
+         .
+         #s(item$
+            Fragment-Supercharger
+            "UT_SHIPSHOT"
+            1
+            (Technology:Ship TechnologyRarity:Impossible TechShopRarity:Common)
+            "Fragment Supercharger"))
+        ("ALLOY3"
+         .
+         #s(item$
+            Herox
+            "ALLOY3"
+            25000
+            (Substance:Stellar Rarity:Rare Product:Tradeable)
+            "Herox"))
+        ("FARMPROD2"
+         .
+         #s(item$
+            Lubricant
+            "FARMPROD2"
+            110000
+            (Substance:Special Rarity:Rare Product:Tradeable)
+            "Lubricant"))
+        ("BOLT_SM"
+         .
+         #s(item$
+            Boltcaster-SM
+            "BOLT_SM"
+            1
+            (Technology:Weapon
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Boltcaster SM"))
+        ("U_SCANNER1"
+         .
+         #s(item$
+            |Scanner-Module-(C)|
+            "U_SCANNER1"
+            60
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Scanner Module (C)"))
+        ("T_SMG"
+         .
+         #s(item$
+            Upgrade-Module
+            "T_SHIPJUMP"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Upgrade Module"))
+        ("MAINT_REFINER"
+         .
+         #s(item$
+            Refinery-Output
+            "MAINT_REFINER"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Refinery Output"))
+        ("CORRIDORC"
+         .
+         #s(item$
+            Curved-Corridor
+            "CORRIDORC"
+            3
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Curved Corridor"))
+        ("U_EXO_ENG3"
+         .
+         #s(item$
+            |Exocraft-Engine-Module-(A)|
+            "U_EXO_ENG3"
+            240
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Exocraft Engine Module (A)"))
+        ("CATALYST1"
+         .
+         #s(item$ Sodium "CATALYST1" 41 (Rarity:Uncommon) "Sodium"))
+        ("BUILDDECALNUM9"
+         .
+         #s(item$
+            Decal
+            "BUILDDECAL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Decal"))
+        ("LASER_XO"
+         .
+         #s(item$
+            Plasma-Resonator
+            "LASER_XO"
+            1
+            (Technology:Weapon
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Plasma Resonator"))
+        ("SUMMON_GARAGE"
+         .
+         #s(item$
+            Exocraft-Summoning-Station
+            "SUMMON_GARAGE"
+            10
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Exocraft Summoning Station"))
+        ("SHIPSLOT_DMG6"
+         .
+         #s(item$
+            Damaged-Gears
+            "SHIPSLOT_DMG6"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Damaged Gears"))
+        ("U_SHIPSHOT1"
+         .
+         #s(item$
+            |Positron-Module-(C)|
+            "U_SHIPSHOT1"
+            60
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Positron Module (C)"))
+        ("CORRIDORT"
+         .
+         #s(item$
+            T=Shaped-Corridor
+            "CORRIDORT"
+            5
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "T-Shaped Corridor"))
+        ("M_DOOR_H"
+         .
+         #s(item$
+            Metal-Doorway
+            "M_DOOR_H"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Metal Doorway"))
+        ("GARAGE_S"
+         .
+         #s(item$
+            Nomad-Geobay
+            "GARAGE_S"
+            10
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Nomad Geobay"))
+        ("SPACEGUNK4"
+         .
+         #s(item$
+            Living-Slime
+            "SPACEGUNK4"
+            20
+            (Rarity:Uncommon)
+            "Living Slime"))
+        ("TRA_ALLOY4"
+         .
+         #s(item$
+            Five-Dimensional-Torus
+            "TRA_ALLOY4"
+            30000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "Five Dimensional Torus"))
+        ("CONTAINER4"
+         .
+         #s(item$
+            Storage-Container
+            "CONTAINER0"
+            5
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Storage Container"))
+        ("U_EXOBOOST2"
+         .
+         #s(item$
+            |Exocraft-Boost-Module-(B)|
+            "U_EXOBOOST2"
+            140
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Exocraft Boost Module (B)"))
+        ("S_CONTAINER5"
+         .
+         #s(item$
+            Freighter-Storage-Unit
+            "S_CONTAINER0"
+            5
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Freighter Storage Unit"))
+        ("UT_SHIPLAS"
+         .
+         #s(item$
+            Fourier-De=Limiter
+            "UT_SHIPLAS"
+            1
+            (Technology:Ship TechnologyRarity:Normal TechShopRarity:Common)
+            "Fourier De-Limiter"))
+        ("U_RAIL2"
+         .
+         #s(item$
+            |Blaze-Javelin-Module-(B)|
+            "U_RAIL2"
+            140
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Blaze Javelin Module (B)"))
+        ("CUBEWALL"
+         .
+         #s(item$
+            Cuboid-Inner-Wall
+            "CUBEWALL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Cuboid Inner Wall"))
+        ("U_SHIPLAS1"
+         .
+         #s(item$
+            |Phase-Beam-Module-(C)|
+            "U_SHIPLAS1"
+            60
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Phase Beam Module (C)"))
+        ("MAINROOM"
+         .
+         #s(item$
+            Cylindrical-Room
+            "MAINROOM"
+            3
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Cylindrical Room"))
+        ("LASER"
+         .
+         #s(item$
+            Mining-Beam
+            "LASER"
+            1
+            (Technology:Weapon TechnologyRarity:Always TechShopRarity:Always)
+            "Mining Beam"))
+        ("GRENFUEL1"
+         .
+         #s(item$
+            Unstable-Plasma
+            "GRENFUEL1"
+            5750
+            (Substance:Fuel Rarity:Rare Product:Consumable)
+            "Unstable Plasma"))
+        ("ENERGY"
+         .
+         #s(item$
+            Life-Support
+            "ENERGY"
+            1
+            (Technology:Suit TechnologyRarity:Always TechShopRarity:Impossible)
+            "Life Support"))
+        ("FRIG_BOOST_SPD"
+         .
+         #s(item$
+            Fuel-Oxidiser
+            "FRIG_BOOST_SPD"
+            75000
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Fuel Oxidiser"))
+        ("W_ROOF"
+         .
+         #s(item$
+            Wooden-Roof
+            "W_ROOF"
+            2
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Wooden Roof"))
+        ("UT_WATERENERGY"
+         .
+         #s(item$
+            Oxygen-Rerouter
+            "UT_WATERENERGY"
+            1
+            (Technology:Suit TechnologyRarity:Common TechShopRarity:Common)
+            "Oxygen Rerouter"))
+        ("BUILDDECALHELLO"
+         .
+         #s(item$
+            Decal
+            "BUILDDECAL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Decal"))
+        ("STATUE_SHIP_B"
+         .
+         #s(item$
+            Bronze-Fighter-Statue
+            "STATUE_SHIP_B"
+            300
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Bronze Fighter Statue"))
+        ("VEHICLE_GRIP3"
+         .
+         #s(item$
+            Hi=Slide-Suspension
+            "VEHICLE_GRIP3"
+            1
+            (Technology:Exocraft
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Hi-Slide Suspension"))
+        ("U_PULSE4"
+         .
+         #s(item$
+            |Pulse-Engine-Module-(S)|
+            "U_PULSE4"
+            360
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Pulse Engine Module (S)"))
+        ("TRA_TECH3"
+         .
+         #s(item$
+            Ion-Capacitor
+            "TRA_TECH3"
+            15000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "Ion Capacitor"))
+        ("WALLSCREENB"
+         .
+         #s(item$
+            Green-Wall-Screen
+            "WALLSCREENB"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Green Wall Screen"))
+        ("STATUE_WALK_S"
+         .
+         #s(item$
+            Silver-Walker-Statue
+            "STATUE_WALK_S"
+            400
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Silver Walker Statue"))
+        ("FUEL1" . #s(item$ Carbon "FUEL1" 12 (Rarity:Common) "Carbon"))
+        ("C_WALLDIAGONAL"
+         .
+         #s(item$
+            Sloping-Concrete-Panel
+            "C_WALLDIAGONAL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Sloping Concrete Panel"))
+        ("MAINT_PORTAL3"
+         .
+         #s(item$
+            Portal-Glyph
+            "MAINT_PORTAL1"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Portal Glyph"))
+        ("S_CONTAINER9"
+         .
+         #s(item$
+            Freighter-Storage-Unit
+            "S_CONTAINER0"
+            5
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Freighter Storage Unit"))
+        ("CONTAINER7"
+         .
+         #s(item$
+            Storage-Container
+            "CONTAINER0"
+            5
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Storage Container"))
+        ("W_WALL_Q"
+         .
+         #s(item$
+            Small-Wooden-Wall
+            "W_WALL_Q"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Small Wooden Wall"))
+        ("MAINT_FRIG1"
+         .
+         #s(item$
+            Tiny-motor
+            "MAINT_TECH7"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Tiny motor"))
+        ("U_PULSE1"
+         .
+         #s(item$
+            |Pulse-Engine-Module-(C)|
+            "U_PULSE1"
+            60
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Pulse Engine Module (C)"))
+        ("MAINT_FARM3"
+         .
+         #s(item$
+            Light-Balancer
+            "MAINT_FARM3"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Light Balancer"))
+        ("U_EXO_SUB1"
+         .
+         #s(item$
+            |Humboldt-Drive-Module-(C)|
+            "U_EXO_SUB1"
+            60
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Humboldt Drive Module (C)"))
+        ("FRIG_BOOST_MIN"
+         .
+         #s(item$
+            Mineral-Compressor
+            "FRIG_BOOST_MIN"
+            75000
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Mineral Compressor"))
+        ("M_ROOF"
+         .
+         #s(item$
+            Metal-Roof
+            "M_ROOF"
+            2
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Metal Roof"))
+        ("U_EXOLAS2"
+         .
+         #s(item$
+            |Exocraft-Laser-Module-(B)|
+            "U_EXOLAS2"
+            140
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Exocraft Laser Module (B)"))
+        ("SMG"
+         .
+         #s(item$
+            Pulse-Spitter
+            "SMG"
+            1
+            (Technology:Weapon TechnologyRarity:Common TechShopRarity:Common)
+            "Pulse Spitter"))
+        ("VEHICLE_GRIP1"
+         .
+         #s(item$
+            Drift-Suspension
+            "VEHICLE_GRIP1"
+            1
+            (Technology:Exocraft
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Drift Suspension"))
+        ("RACE_START"
+         .
+         #s(item$
+            Race-Initiator
+            "RACE_START"
+            10
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Race Initiator"))
+        ("WATERPLANT"
+         .
+         #s(item$
+            Cyto=Phosphate
+            "WATERPLANT"
+            201
+            (Rarity:Rare)
+            "Cyto-Phosphate"))
+        ("F_HACCESS3"
+         .
+         #s(item$
+            Warp-Shielding-Theta
+            "F_HACCESS3"
+            1
+            (Technology:Freighter
+             TechnologyRarity:Impossible
+             TechShopRarity:Rare)
+            "Warp Shielding Theta"))
+        ("U_EXO_SUB3"
+         .
+         #s(item$
+            |Humboldt-Drive-Module-(A)|
+            "U_EXO_SUB3"
+            240
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Humboldt Drive Module (A)"))
+        ("TRA_ALLOY5"
+         .
+         #s(item$
+            Superconducting-Fibre
+            "TRA_ALLOY5"
+            50000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "Superconducting Fibre"))
+        ("T_COLDPROT"
+         .
+         #s(item$
+            Upgrade-Module
+            "T_SHIPJUMP"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Upgrade Module"))
+        ("MAINT_TECH12"
+         .
+         #s(item$
+            Spring-Casing
+            "MAINT_TECH12"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Spring Casing"))
+        ("U_LASER2"
+         .
+         #s(item$
+            |Mining-Beam-Module-(B)|
+            "U_LASER2"
+            140
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Mining Beam Module (B)"))
+        ("SHIPROCKETS"
+         .
+         #s(item$
+            Rocket-Launcher
+            "SHIPROCKETS"
+            1
+            (Technology:Ship TechnologyRarity:Common TechShopRarity:Common)
+            "Rocket Launcher"))
+        ("TRA_COMMODITY2"
+         .
+         #s(item$
+            TRA_COMMODITY2
+            "TRA_COMMODITY2"
+            6000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "TRA_COMMODITY2"))
+        ("STORAGEPANEL"
+         .
+         #s(item$
+            Storage-Panel
+            "STORAGEPANEL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Storage Panel"))
+        ("BASE_TREE01"
+         .
+         #s(item$
+            Fruit-Tree
+            "BASE_TREE01"
+            500
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Fruit Tree"))
+        ("ULTRAPROD1"
+         .
+         #s(item$
+            Fusion-Ignitor
+            "ULTRAPROD1"
+            15600000
+            (Substance:Special Rarity:Rare Product:Tradeable)
+            "Fusion Ignitor"))
+        ("STRONGLASER"
+         .
+         #s(item$
+            Advanced-Mining-Laser
+            "STRONGLASER"
+            1
+            (Technology:Weapon TechnologyRarity:Common TechShopRarity:Common)
+            "Advanced Mining Laser"))
+        ("MAINT_PORTAL15"
+         .
+         #s(item$
+            Portal-Glyph
+            "MAINT_PORTAL1"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Portal Glyph"))
+        ("MAINT_FUEL2"
+         .
+         #s(item$
+            Membrane-Battery
+            "MAINT_FUEL2"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Membrane Battery"))
+        ("U_GRENADE1"
+         .
+         #s(item$
+            |Plasma-Launcher-Module-(C)|
+            "U_GRENADE1"
+            60
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Plasma Launcher Module (C)"))
+        ("U_SHIPSHOT2"
+         .
+         #s(item$
+            |Positron-Module-(B)|
+            "U_SHIPSHOT2"
+            140
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Positron Module (B)"))
+        ("GAS1" . #s(item$ Sulphurine "GAS1" 20 (Rarity:Common) "Sulphurine"))
+        ("C_DOOR_H"
+         .
+         #s(item$
+            Concrete-Doorway
+            "C_DOOR_H"
+            2
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Concrete Doorway"))
+        ("U_HYPER3"
+         .
+         #s(item$
+            |Hyperdrive-Module-(A)|
+            "U_HYPER3"
+            240
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Hyperdrive Module (A)"))
+        ("NPCEXPLORER001"
+         .
+         #s(item$
+            NPCEXPLORER001
+            "NPCEXPLORER001"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "NPCEXPLORER001"))
+        ("W_ARCH"
+         .
+         #s(item$
+            Wooden-Arch
+            "W_ARCH"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Wooden Arch"))
+        ("POLICE_TOKEN"
+         .
+         #s(item$
+            Defence-Chit
+            "POLICE_TOKEN"
+            10000
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Defence Chit"))
+        ("SHOTGUN"
+         .
+         #s(item$
+            Scatter-Blaster
+            "SHOTGUN"
+            1
+            (Technology:Weapon TechnologyRarity:Common TechShopRarity:Common)
+            "Scatter Blaster"))
+        ("T_EXLAS"
+         .
+         #s(item$
+            Upgrade-Module
+            "T_SHIPJUMP"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Upgrade Module"))
+        ("LUSH1"
+         .
+         #s(item$ Paraffinium "LUSH1" 62 (Rarity:Uncommon) "Paraffinium"))
+        ("TERRAIN_GREN"
+         .
+         #s(item$
+            Geology-Cannon
+            "TERRAIN_GREN"
+            1
+            (Technology:Weapon TechnologyRarity:Common TechShopRarity:Common)
+            "Geology Cannon"))
+        ("T_SUBGUN"
+         .
+         #s(item$
+            Upgrade-Module
+            "T_SHIPJUMP"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Upgrade Module"))
+        ("EXOPOD_TECH2"
+         .
+         #s(item$
+            Damaged-Electrode
+            "EXOPOD_TECH2"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Damaged Electrode"))
+        ("U_SCANNER2"
+         .
+         #s(item$
+            |Scanner-Module-(B)|
+            "U_SCANNER2"
+            140
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Scanner Module (B)"))
+        ("COMPOUND1"
+         .
+         #s(item$
+            Organic-Catalyst
+            "COMPOUND1"
+            320000
+            (Substance:Special Rarity:Rare Product:Tradeable)
+            "Organic Catalyst"))
+        ("LAND1"
+         .
+         #s(item$ Ferrite-Dust "LAND1" 14 (Rarity:Common) "Ferrite Dust"))
+        ("BUILDDECALNUM1"
+         .
+         #s(item$
+            Decal
+            "BUILDDECAL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Decal"))
+        ("W_FLOOR_Q"
+         .
+         #s(item$
+            Small-Wood-Panel
+            "W_FLOOR_Q"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Small Wood Panel"))
+        ("VEHICLE_GRIP2"
+         .
+         #s(item$
+            Grip-Boost-Suspension
+            "VEHICLE_GRIP2"
+            1
+            (Technology:Exocraft
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Grip Boost Suspension"))
+        ("CORRIDOR_WINDOW"
+         .
+         #s(item$
+            CORRIDOR_WINDOW
+            "CORRIDOR_WINDOW"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "CORRIDOR_WINDOW"))
+        ("CORRIDORX_WATER"
+         .
+         #s(item$
+            X=Shaped-Glass-Tunnel
+            "CORRIDORX_WATER"
+            3
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "X-Shaped Glass Tunnel"))
+        ("T_JET"
+         .
+         #s(item$
+            Upgrade-Module
+            "T_SHIPJUMP"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Upgrade Module"))
+        ("U_GRENADE3"
+         .
+         #s(item$
+            |Plasma-Launcher-Module-(A)|
+            "U_GRENADE3"
+            240
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Plasma Launcher Module (A)"))
+        ("FLAG2"
+         .
+         #s(item$
+            Flag
+            "FLAG1"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Flag"))
+        ("F_HDRIVEBOOST3"
+         .
+         #s(item$
+            Freighter-Warp-Reactor-Theta
+            "F_HDRIVEBOOST3"
+            1
+            (Technology:Freighter
+             TechnologyRarity:Impossible
+             TechShopRarity:Rare)
+            "Freighter Warp Reactor Theta"))
+        ("U_UNW3"
+         .
+         #s(item$
+            |Underwater-Protection-Module-(S)|
+            "U_UNW3"
+            360
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Underwater Protection Module (S)"))
+        ("UT_RAIL"
+         .
+         #s(item$
+            Mass-Accelerator
+            "UT_RAIL"
+            1
+            (Technology:Weapon TechnologyRarity:Common TechShopRarity:Common)
+            "Mass Accelerator"))
+        ("MESSAGE"
+         .
+         #s(item$
+            Communications-Station
+            "MESSAGE"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Communications Station"))
+        ("BUILDSOFA2"
+         .
+         #s(item$
+            Swept-Sofa
+            "BUILDSOFA2"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Swept Sofa"))
+        ("WATERPROD3"
+         .
+         #s(item$
+            Chloride-Lattice
+            "WATERPROD3"
+            6150
+            (Substance:Exotic Rarity:Rare Product:Curiousity)
+            "Chloride Lattice"))
+        ("TRA_MINERALS5"
+         .
+         #s(item$
+            Re=latticed-Arc-Crystal
+            "TRA_MINERALS5"
+            50000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "Re-latticed Arc Crystal"))
+        ("TRA_TECH1"
+         .
+         #s(item$
+            Decommissioned-Circuit-Board
+            "TRA_TECH1"
+            1000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "Decommissioned Circuit Board"))
+        ("FOUNDLEG4"
+         .
+         #s(item$
+            Foundation-Strut-Quad
+            "FOUNDLEG4"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Foundation Strut Quad"))
+        ("FARMPROD4"
+         .
+         #s(item$
+            Heat-Capacitor
+            "FARMPROD4"
+            180000
+            (Substance:Special Rarity:Rare Product:Tradeable)
+            "Heat Capacitor"))
+        ("W_ROOF_C"
+         .
+         #s(item$
+            Wooden-Roof-Corner
+            "W_ROOF_C"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Wooden Roof Corner"))
+        ("HEALTHPLANT"
+         .
+         #s(item$
+            HEALTHPLANT
+            "HEALTHPLANT"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "HEALTHPLANT"))
+        ("U_SHIPBLOB2"
+         .
+         #s(item$
+            |Cyclotron-Module-(B)|
+            "U_SHIPBLOB2"
+            140
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Cyclotron Module (B)"))
+        ("SPACEGUNK5"
+         .
+         #s(item$
+            Viscous-Fluids
+            "SPACEGUNK5"
+            20
+            (Rarity:Rare)
+            "Viscous Fluids"))
+        ("SHIPSCAN_COMBAT"
+         .
+         #s(item$
+            Conflict-Scanner
+            "SHIPSCAN_COMBAT"
+            1
+            (Technology:Ship TechnologyRarity:Normal TechShopRarity:Common)
+            "Conflict Scanner"))
+        ("PRODFUEL1"
+         .
+         #s(item$
+            Oxygen-Capsule
+            "PRODFUEL1"
+            350
+            (Substance:Fuel Rarity:Rare Product:Consumable)
+            "Oxygen Capsule"))
+        ("PEARLPLANT"
+         .
+         #s(item$
+            Albumen-Pearl-Orb
+            "PEARLPLANT"
+            3
+            (Substance:BuildingPart Rarity:Rare Product:BuildingPart)
+            "Albumen Pearl Orb"))
+        ("T_HOTPROT"
+         .
+         #s(item$
+            Upgrade-Module
+            "T_SHIPJUMP"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Upgrade Module"))
+        ("STATUE_ATLAS_S"
+         .
+         #s(item$
+            Silver-Atlas-Statue
+            "STATUE_ATLAS_S"
+            400
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Silver Atlas Statue"))
+        ("BLUE2" . #s(item$ Indium "BLUE2" 464 (Rarity:Rare) "Indium"))
+        ("U_EXOBOOST4"
+         .
+         #s(item$
+            |Exocraft-Boost-Module-(S)|
+            "U_EXOBOOST4"
+            360
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Exocraft Boost Module (S)"))
+        ("SNOWPLANT"
+         .
+         #s(item$
+            Frostwort
+            "SNOWPLANT"
+            3
+            (Substance:BuildingPart Rarity:Rare Product:BuildingPart)
+            "Frostwort"))
+        ("LANDPROD3"
+         .
+         #s(item$
+            Rare-Metal-Element
+            "LANDPROD3"
+            4200
+            (Substance:Exotic Rarity:Rare Product:Curiousity)
+            "Rare Metal Element"))
+        ("WAR_CURIO1"
+         .
+         #s(item$
+            |Vy'keen-Effigy|
+            "WAR_CURIO1"
+            24750
+            (Substance:Exotic Rarity:Rare Product:Curiousity)
+            "Vy'keen Effigy"))
+        ("FARMPROD9"
+         .
+         #s(item$
+            Circuit-Board
+            "FARMPROD9"
+            916250
+            (Substance:Special Rarity:Rare Product:Tradeable)
+            "Circuit Board"))
+        ("GARAGE_B"
+         .
+         #s(item$
+            Pilgrim-Geobay
+            "GARAGE_B"
+            10
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Pilgrim Geobay"))
+        ("NPCWEAPONTERM"
+         .
+         #s(item$
+            Weapons-Terminal
+            "NPCWEAPONTERM"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Weapons Terminal"))
+        ("SHIPLAS1"
+         .
+         #s(item$
+            Phase-Beam
+            "SHIPLAS1"
+            1
+            (Technology:Ship TechnologyRarity:Rare TechShopRarity:Common)
+            "Phase Beam"))
+        ("S_CONTAINER2"
+         .
+         #s(item$
+            Freighter-Storage-Unit
+            "S_CONTAINER0"
+            5
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Freighter Storage Unit"))
+        ("PLANT_LUSH"
+         .
+         #s(item$ Star-Bulb "PLANT_LUSH" 32 (Rarity:Rare) "Star Bulb"))
+        ("MAINROOMCUBEF"
+         .
+         #s(item$
+            Square-Room
+            "MAINROOMCUBE"
+            3
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Square Room"))
+        ("U_SHIPMINI3"
+         .
+         #s(item$
+            |Infra=Knife-Module-(A)|
+            "U_SHIPMINI3"
+            240
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Infra-Knife Module (A)"))
+        ("MAINROOMFRAME"
+         .
+         #s(item$
+            Cylindrical-Room-Frame
+            "MAINROOMFRAME"
+            3
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Cylindrical Room Frame"))
+        ("SPEC_DECAL03"
+         .
+         #s(item$
+            Hand-of-Approval-Decal
+            "SPEC_DECAL03"
+            400
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Hand of Approval Decal"))
+        ("GREEN2" . #s(item$ Emeril "GREEN2" 348 (Rarity:Rare) "Emeril"))
+        ("CUBEWINDOWOVAL"
+         .
+         #s(item$
+            Window
+            "BUILDWINDOW"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Window"))
+        ("SPEC_EMOTE02"
+         .
+         #s(item$
+            Celebrate!
+            "SPEC_EMOTE02"
+            1500
+            (Substance:Exotic Rarity:Common Product:Emote)
+            "Celebrate!"))
+        ("MAINT_PORTAL1"
+         .
+         #s(item$
+            Portal-Glyph
+            "MAINT_PORTAL1"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Portal Glyph"))
+        ("BP_SALVAGE"
+         .
+         #s(item$
+            Salvaged-Technology
+            "BP_SALVAGE"
+            50000
+            (Substance:Exotic Rarity:Rare Product:Curiousity)
+            "Salvaged Technology"))
+        ("BUILDHARVESTER"
+         .
+         #s(item$
+            Autonomous-Mining-Unit
+            "BUILDHARVESTER"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Autonomous Mining Unit"))
+        ("M_WALL_Q_H"
+         .
+         #s(item$
+            Short-Metal-Wall
+            "M_WALL_Q_H"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Short Metal Wall"))
+        ("U_SCANNER4"
+         .
+         #s(item$
+            |Scanner-Module-(S)|
+            "U_SCANNER4"
+            360
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Scanner Module (S)"))
+        ("MAINT_FRIG5"
+         .
+         #s(item$
+            Solenoid
+            "MAINT_TECH16"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Solenoid"))
+        ("U_SHOTGUN3"
+         .
+         #s(item$
+            |Scatter-Blaster-Module-(A)|
+            "U_SHOTGUN3"
+            240
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Scatter Blaster Module (A)"))
+        ("U_SMG1"
+         .
+         #s(item$
+            |Pulse-Spitter-Module-(C)|
+            "U_SMG1"
+            60
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Pulse Spitter Module (C)"))
+        ("COMPOUND2"
+         .
+         #s(item$
+            Semiconductor
+            "COMPOUND2"
+            320000
+            (Substance:Special Rarity:Rare Product:Tradeable)
+            "Semiconductor"))
+        ("U_EXO_SUB4"
+         .
+         #s(item$
+            |Humboldt-Drive-Module-(S)|
+            "U_EXO_SUB4"
+            360
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Humboldt Drive Module (S)"))
+        ("ASTEROID3"
+         .
+         #s(item$ Platinum "ASTEROID3" 303 (Rarity:Rare) "Platinum"))
+        ("SPEC_EMOTE04"
+         .
+         #s(item$
+            Wonder
+            "SPEC_EMOTE04"
+            1500
+            (Substance:Exotic Rarity:Common Product:Emote)
+            "Wonder"))
+        ("WEDGESMALLSHAPE"
+         .
+         #s(item$
+            Small-Wedge
+            "WEDGESMALLSHAPE"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Small Wedge"))
+        ("U_SHIPMINI1"
+         .
+         #s(item$
+            |Infra=Knife-Module-(C)|
+            "U_SHIPMINI1"
+            60
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Infra-Knife Module (C)"))
+        ("CURVEPIPESHAPE"
+         .
+         #s(item$
+            Curved-Pipe
+            "CURVEPIPESHAPE"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Curved Pipe"))
+        ("C_ROOF"
+         .
+         #s(item$
+            Concrete-Roof
+            "C_ROOF"
+            2
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Concrete Roof"))
+        ("SHIPGUN1"
+         .
+         #s(item$
+            Photon-Cannon
+            "SHIPGUN1"
+            1
+            (Technology:Ship TechnologyRarity:Always TechShopRarity:Impossible)
+            "Photon Cannon"))
+        ("W_FLOOR"
+         .
+         #s(item$
+            Wood-Floor-Panel
+            "W_FLOOR"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Wood Floor Panel"))
+        ("TRA_TECH2"
+         .
+         #s(item$
+            Welding-Soap
+            "TRA_TECH2"
+            6000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "Welding Soap"))
+        ("U_JETBOOST2"
+         .
+         #s(item$
+            |Movement-Module-(B)|
+            "U_JETBOOST2"
+            140
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Movement Module (B)"))
+        ("STATUE_DIP_B"
+         .
+         #s(item$
+            Bronze-Diplo-Statue
+            "STATUE_DIP_B"
+            300
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Bronze Diplo Statue"))
+        ("NAV_DATA"
+         .
+         #s(item$
+            Navigation-Data
+            "NAV_DATA"
+            1000
+            (Substance:Special Rarity:Rare Product:Curiousity)
+            "Navigation Data"))
+        ("U_SHIPGUN1"
+         .
+         #s(item$
+            |Photon-Cannon-Module-(C)|
+            "U_SHIPGUN1"
+            60
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Photon Cannon Module (C)"))
+        ("SHIPSCAN_ECON"
+         .
+         #s(item$
+            Economy-Scanner
+            "SHIPSCAN_ECON"
+            1
+            (Technology:Ship TechnologyRarity:Normal TechShopRarity:Common)
+            "Economy Scanner"))
+        ("NIPNIPBUDS"
+         .
+         #s(item$
+            NipNip-Buds
+            "NIPNIPBUDS"
+            17776
+            (Substance:Exotic Rarity:Rare Product:Curiousity)
+            "NipNip Buds"))
+        ("MAINT_TECH15"
+         .
+         #s(item$
+            Servo-Arm
+            "MAINT_TECH15"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Servo Arm"))
+        ("MAINT_TECH20"
+         .
+         #s(item$
+            Load-Balancer
+            "MAINT_TECH20"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Load Balancer"))
+        ("WEAPSLOT_DMG2"
+         .
+         #s(item$
+            Blown-Transistor
+            "WEAPSLOT_DMG2"
+            1
+            (Technology:Weapon
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Blown Transistor"))
+        ("STATUE_DIP_S"
+         .
+         #s(item$
+            Silver-Diplo-Statue
+            "STATUE_DIP_S"
+            400
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Silver Diplo Statue"))
+        ("SHIPJUMP1"
+         .
+         #s(item$
+            Pulse-Engine
+            "SHIPJUMP1"
+            1
+            (Technology:Ship TechnologyRarity:Always TechShopRarity:Impossible)
+            "Pulse Engine"))
+        ("CUBEWALL_SPACE"
+         .
+         #s(item$
+            Internal-Freighter-Wall
+            "CUBEWALL_SPACE"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Internal Freighter Wall"))
+        ("MAINT_TECH5"
+         .
+         #s(item$
+            Bio=input-sensor
+            "MAINT_TECH5"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Bio-input sensor"))
+        ("W_WALLDIAGONAL"
+         .
+         #s(item$
+            Sloping-Wood-Panel
+            "W_WALLDIAGONAL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Sloping Wood Panel"))
+        ("U_JETBOOST3"
+         .
+         #s(item$
+            |Movement-Module-(A)|
+            "U_JETBOOST3"
+            240
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Movement Module (A)"))
+        ("WALLTALL"
+         .
+         #s(item$
+            Large-Wall
+            "WALLTALL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Large Wall"))
+        ("YELLOW2" . #s(item$ Copper "YELLOW2" 121 (Rarity:Common) "Copper"))
+        ("W_SDOOR"
+         .
+         #s(item$
+            Small-Wooden-Door
+            "W_SDOOR"
+            2
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Small Wooden Door"))
+        ("U_ENERGY2"
+         .
+         #s(item$
+            |Life-Support-Module-(A)|
+            "U_ENERGY2"
+            240
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Life Support Module (A)"))
+        ("M_RAMP_H"
+         .
+         #s(item$
+            Metal-Half-Ramp
+            "M_RAMP_H"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Metal Half Ramp"))
+        ("LAUNCHFUEL"
+         .
+         #s(item$
+            Starship-Launch-Fuel
+            "LAUNCHFUEL"
+            450
+            (Substance:Fuel Rarity:Uncommon Product:Consumable)
+            "Starship Launch Fuel"))
+        ("U_EXO_ENG4"
+         .
+         #s(item$
+            |Exocraft-Engine-Module-(S)|
+            "U_EXO_ENG4"
+            360
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Exocraft Engine Module (S)"))
+        ("BUILDDECALNMS"
+         .
+         #s(item$
+            Decal
+            "BUILDDECAL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Decal"))
+        ("SPACEGUNK3"
+         .
+         #s(item$
+            Rusted-Metal
+            "SPACEGUNK3"
+            20
+            (Rarity:Uncommon)
+            "Rusted Metal"))
+        ("ALLOY8"
+         .
+         #s(item$
+            Iridesite
+            "ALLOY8"
+            150000
+            (Substance:Stellar Rarity:Rare Product:Tradeable)
+            "Iridesite"))
+        ("TRA_COMMODITY1"
+         .
+         #s(item$
+            TRA_COMMODITY1
+            "TRA_COMMODITY1"
+            1000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "TRA_COMMODITY1"))
+        ("C_FLOOR_Q"
+         .
+         #s(item$
+            Small-Concrete-Panel
+            "C_FLOOR_Q"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Small Concrete Panel"))
+        ("LARGEDESK"
+         .
+         #s(item$
+            Large-Monitor-Station
+            "LARGEDESK"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Large Monitor Station"))
+        ("MAINT_TECH21"
+         .
+         #s(item$
+            Network-Interface
+            "MAINT_TECH21"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Network Interface"))
+        ("SHIP_TELEPORT"
+         .
+         #s(item$
+            Teleport-Receiver
+            "SHIP_TELEPORT"
+            1
+            (Technology:Ship TechnologyRarity:VeryRare TechShopRarity:Common)
+            "Teleport Receiver"))
+        ("STARSUIT"
+         .
+         #s(item$
+            Star-Seed
+            "STARSUIT"
+            1
+            (Technology:Suit
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Star Seed"))
+        ("SUB_BINOCS"
+         .
+         #s(item$
+            High=Power-Sonar
+            "SUB_BINOCS"
+            1
+            (Technology:Submarine
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "High-Power Sonar"))
+        ("HDRIVEBOOST3"
+         .
+         #s(item$
+            Indium-Drive
+            "HDRIVEBOOST3"
+            1
+            (Technology:Ship TechnologyRarity:Impossible TechShopRarity:Common)
+            "Indium Drive"))
+        ("BASE_WPLANT1"
+         .
+         #s(item$
+            Curly-Coral
+            "BASE_WPLANT1"
+            500
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Curly Coral"))
+        ("S_CONTAINER4"
+         .
+         #s(item$
+            Freighter-Storage-Unit
+            "S_CONTAINER0"
+            5
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Freighter Storage Unit"))
+        ("M_SDOOR"
+         .
+         #s(item$
+            Small-Metal-Door
+            "M_SDOOR"
+            2
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Small Metal Door"))
+        ("BUILDCANRACK"
+         .
+         #s(item$
+            Canister-Rack
+            "BUILDCANRACK"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Canister Rack"))
+        ("MAINT_FARM1"
+         .
+         #s(item$
+            Soil-De=Wormer
+            "MAINT_FARM1"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Soil De-Wormer"))
+        ("SUB_LASER"
+         .
+         #s(item$
+            Tethys-Beam
+            "SUB_LASER"
+            1
+            (Technology:Submarine
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Tethys Beam"))
+        ("TOXIC1" . #s(item$ Ammonia "TOXIC1" 62 (Rarity:Uncommon) "Ammonia"))
+        ("C_WALL_Q"
+         .
+         #s(item$
+            Small-Concrete-Wall
+            "C_WALL_Q"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Small Concrete Wall"))
+        ("U_EXOLAS3"
+         .
+         #s(item$
+            |Exocraft-Laser-Module-(A)|
+            "U_EXOLAS3"
+            240
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Exocraft Laser Module (A)"))
+        ("TRA_COMPONENT3"
+         .
+         #s(item$
+            TRA_COMPONENT3
+            "TRA_COMPONENT3"
+            15000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "TRA_COMPONENT3"))
+        ("BUILDLABLAMP"
+         .
+         #s(item$
+            Lab-Lamp
+            "BUILDLABLAMP"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Lab Lamp"))
+        ("EXOPOD_TECH1"
+         .
+         #s(item$
+            Faulty-Hologram
+            "EXOPOD_TECH1"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Faulty Hologram"))
+        ("VEHICLE_GUN"
+         .
+         #s(item$
+            Exocraft-Mounted-Cannon
+            "VEHICLE_GUN"
+            1
+            (Technology:Exocraft
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Exocraft Mounted Cannon"))
+        ("FLAG4"
+         .
+         #s(item$
+            Flag
+            "FLAG1"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Flag"))
+        ("NPCBUILDERTERM"
+         .
+         #s(item$
+            Construction-Terminal
+            "NPCBUILDERTERM"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Construction Terminal"))
+        ("C_WALL_Q_H"
+         .
+         #s(item$
+            Short-Concrete-Wall
+            "C_WALL_Q_H"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Short Concrete Wall"))
+        ("CYLINDERSHAPE"
+         .
+         #s(item$
+            Cylinder
+            "CYLINDERSHAPE"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Cylinder"))
+        ("MAINT_PORTAL11"
+         .
+         #s(item$
+            Portal-Glyph
+            "MAINT_PORTAL1"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Portal Glyph"))
+        ("CUBEROOM_SPACE"
+         .
+         #s(item$
+            Large-Freighter-Room
+            "CUBEROOM_SPACE"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Large Freighter Room"))
+        ("REACTION2"
+         .
+         #s(item$
+            Enriched-Carbon
+            "REACTION2"
+            50000
+            (Substance:Special Rarity:Rare Product:Tradeable)
+            "Enriched Carbon"))
+        ("MAINT_TECH9"
+         .
+         #s(item$
+            Output-screen
+            "MAINT_TECH9"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Output screen"))
+        ("U_SHIELDBOOST1"
+         .
+         #s(item$
+            |Shield-Module-(C)|
+            "U_SHIELDBOOST1"
+            60
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Shield Module (C)"))
+        ("MAINT_FRIG2"
+         .
+         #s(item$
+            Cooling-system
+            "MAINT_TECH8"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Cooling system"))
+        ("U_HOTPROT1"
+         .
+         #s(item$
+            |Thermal-Protection-Module-(B)|
+            "U_HOTPROT1"
+            140
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Thermal Protection Module (B)"))
+        ("CATAPROD3"
+         .
+         #s(item$
+            Destablised-Sodium
+            "CATAPROD3"
+            12300
+            (Substance:Exotic Rarity:Rare Product:Curiousity)
+            "Destablised Sodium"))
+        ("BUILDTERMINAL"
+         .
+         #s(item$
+            Galactic-Trade-Terminal
+            "BUILDTERMINAL"
+            10
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Galactic Trade Terminal"))
+        ("U_SMG2"
+         .
+         #s(item$
+            |Pulse-Spitter-Module-(B)|
+            "U_SMG2"
+            140
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Pulse Spitter Module (B)"))
+        ("F_HACCESS1"
+         .
+         #s(item$
+            Warp-Shielding-Sigma
+            "F_HACCESS1"
+            1
+            (Technology:Freighter
+             TechnologyRarity:Impossible
+             TechShopRarity:Normal)
+            "Warp Shielding Sigma"))
+        ("TERRAINEDITOR"
+         .
+         #s(item$
+            Terrain-Manipulator
+            "TERRAINEDITOR"
+            1
+            (Technology:Weapon TechnologyRarity:Common TechShopRarity:Common)
+            "Terrain Manipulator"))
+        ("SPEC_DECAL04"
+         .
+         #s(item$
+            Nada-Decal
+            "SPEC_DECAL04"
+            400
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Nada Decal"))
+        ("U_LASER3"
+         .
+         #s(item$
+            |Mining-Beam-Module-(A)|
+            "U_LASER3"
+            240
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Mining Beam Module (A)"))
+        ("TRA_CURIO2"
+         .
+         #s(item$
+            GekNip
+            "TRA_CURIO2"
+            20625
+            (Substance:Exotic Rarity:Uncommon Product:Curiousity)
+            "GekNip"))
+        ("WALLFAN"
+         .
+         #s(item$
+            Wall-Fan
+            "WALLFAN"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Wall Fan"))
+        ("STATUE_ASTRO_B"
+         .
+         #s(item$
+            Bronze-Astronaut-Statue
+            "STATUE_ASTRO_B"
+            300
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Bronze Astronaut Statue"))
+        ("RACE_START_SHIP"
+         .
+         #s(item$
+            Starship-Race-Initiator
+            "RACE_START_SHIP"
+            10
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Starship Race Initiator"))
+        ("U_SHIPGUN4"
+         .
+         #s(item$
+            |Photon-Cannon-Module-(S)|
+            "U_SHIPGUN4"
+            360
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Photon Cannon Module (S)"))
+        ("TRA_ENERGY1"
+         .
+         #s(item$
+            Spark-Canister
+            "TRA_ENERGY1"
+            1000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "Spark Canister"))
+        ("HDRIVEBOOST2"
+         .
+         #s(item$
+            Emeril-Drive
+            "HDRIVEBOOST2"
+            1
+            (Technology:Ship TechnologyRarity:VeryRare TechShopRarity:Common)
+            "Emeril Drive"))
+        ("CASING"
+         .
+         #s(item$
+            Metal-Plating
+            "CASING"
+            800
+            (Substance:Catalyst Rarity:Common Product:Component)
+            "Metal Plating"))
+        ("U_SHIELDBOOST2"
+         .
+         #s(item$
+            |Shield-Module-(B)|
+            "U_SHIELDBOOST2"
+            140
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Shield Module (B)"))
+        ("STATUE_GEK_G"
+         .
+         #s(item$
+            Gold-Gek-Statue
+            "STATUE_GEK_G"
+            500
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Gold Gek Statue"))
+        ("MAINT_FRIG9"
+         .
+         #s(item$
+            Photovoltaic-Panel
+            "MAINT_TECH24"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Photovoltaic Panel"))
+        ("CHEST"
+         .
+         #s(item$
+            Storage-Container
+            "CONTAINER0"
+            5
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Storage Container"))
+        ("CREATURE1"
+         .
+         #s(item$ Mordite "CREATURE1" 40 (Rarity:Common) "Mordite"))
+        ("RACE_BOOSTER"
+         .
+         #s(item$
+            Race-Force-Amplifier
+            "RACE_BOOSTER"
+            10
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Race Force Amplifier"))
+        ("OBSOLETE"
+         .
+         #s(item$
+            Obsolete-Technology
+            "OBSOLETE"
+            1
+            (Technology:Suit
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Obsolete Technology"))
+        ("TRA_COMPONENT5"
+         .
+         #s(item$
+            TRA_COMPONENT5
+            "TRA_COMPONENT5"
+            50000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "TRA_COMPONENT5"))
+        ("BUILDDECALSIMP4"
+         .
+         #s(item$
+            Decal
+            "BUILDDECAL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Decal"))
+        ("FARMPROD5"
+         .
+         #s(item$
+            Poly-Fibre
+            "FARMPROD5"
+            130000
+            (Substance:Special Rarity:Rare Product:Tradeable)
+            "Poly Fibre"))
+        ("WALLLIGHTWHITE"
+         .
+         #s(item$
+            Coloured-Light
+            "WALLLIGHTBLUE"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Coloured Light"))
+        ("CATALYST2"
+         .
+         #s(item$
+            Sodium-Nitrate
+            "CATALYST2"
+            82
+            (Rarity:Rare)
+            "Sodium Nitrate"))
+        ("BUILDLCRATE"
+         .
+         #s(item$
+            Locked-Crate
+            "BUILDLCRATE"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Locked Crate"))
+        ("WATER1" . #s(item$ Salt "WATER1" 299 (Rarity:Common) "Salt"))
+        ("MAINT_TECH24"
+         .
+         #s(item$
+            Photovoltaic-Panel
+            "MAINT_TECH24"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Photovoltaic Panel"))
+        ("AMMO"
+         .
+         #s(item$
+            Projectile-Ammunition
+            "AMMO"
+            5
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Projectile Ammunition"))
+        ("BUILDBED"
+         .
+         #s(item$
+            Bed
+            "BUILDBED"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Bed"))
+        ("MAINT_FARM2"
+         .
+         #s(item$
+            Auto-Sprinkler
+            "MAINT_FARM2"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Auto Sprinkler"))
+        ("C_ROOF_C"
+         .
+         #s(item$
+            Concrete-Roof-Corner
+            "C_ROOF_C"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Concrete Roof Corner"))
+        ("FLAG3"
+         .
+         #s(item$
+            Flag
+            "FLAG1"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Flag"))
+        ("BUILDSAVE"
+         .
+         #s(item$
+            Save-Point
+            "BUILDSAVE"
+            2
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Save Point"))
+        ("MAINT_TECH18"
+         .
+         #s(item$
+            Master-Circuit
+            "MAINT_TECH18"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Master Circuit"))
+        ("BUILDPAVING_BIG"
+         .
+         #s(item$
+            Paving
+            "BUILDPAVING"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Paving"))
+        ("LAND2"
+         .
+         #s(item$ Pure-Ferrite "LAND2" 28 (Rarity:Uncommon) "Pure Ferrite"))
+        ("MAINROOM_WATER"
+         .
+         #s(item$
+            Deepwater-Chamber
+            "MAINROOM_WATER"
+            6
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Deepwater Chamber"))
+        ("U_GRENADE4"
+         .
+         #s(item$
+            |Plasma-Launcher-Module-(S)|
+            "U_GRENADE4"
+            360
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Plasma Launcher Module (S)"))
+        ("SMALLLIGHT"
+         .
+         #s(item$
+            Light
+            "SMALLLIGHT"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Light"))
+        ("MAINT_TECH23"
+         .
+         #s(item$
+            Alternator
+            "MAINT_TECH23"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Alternator"))
+        ("MOONPOOL"
+         .
+         #s(item$
+            Moon-Pool-Floor
+            "MOONPOOL"
+            10
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Moon Pool Floor"))
+        ("TELEPORTER"
+         .
+         #s(item$
+            Base-Teleport-Module
+            "TELEPORTER"
+            2
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Base Teleport Module"))
+        ("U_EXO_SUBGUN4"
+         .
+         #s(item$
+            |Nautilon-Cannon-Module-(S)|
+            "U_EXO_SUBGUN4"
+            360
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Nautilon Cannon Module (S)"))
+        ("S_CONTAINER0"
+         .
+         #s(item$
+            Freighter-Storage-Unit
+            "S_CONTAINER0"
+            5
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Freighter Storage Unit"))
+        ("PRODFUEL2"
+         .
+         #s(item$
+            Life-Support-Gel
+            "PRODFUEL2"
+            200
+            (Substance:Fuel Rarity:Uncommon Product:Consumable)
+            "Life Support Gel"))
+        ("NIPPLANT"
+         .
+         #s(item$
+            NipNip
+            "NIPPLANT"
+            3
+            (Substance:BuildingPart Rarity:Rare Product:BuildingPart)
+            "NipNip"))
+        ("ACCESS2"
+         .
+         #s(item$
+            AtlasPass-v2
+            "ACCESS2"
+            1856
+            (Substance:Stellar Rarity:Uncommon Product:Curiousity)
+            "AtlasPass v2"))
+        ("PLANTERMEGA"
+         .
+         #s(item$
+            Large-Hydroponic-Tray
+            "PLANTERMEGA"
+            10
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Large Hydroponic Tray"))
+        ("T_GRENADE"
+         .
+         #s(item$
+            Upgrade-Module
+            "T_SHIPJUMP"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Upgrade Module"))
+        ("U_SHIPSHOT4"
+         .
+         #s(item$
+            |Positron-Module-(S)|
+            "U_SHIPSHOT4"
+            360
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Positron Module (S)"))
+        ("WALLDOOR"
+         .
+         #s(item$
+            Shutter-Door
+            "WALLDOOR"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Shutter Door"))
+        ("BUILDCHAIR2"
+         .
+         #s(item$
+            Chair
+            "BUILDCHAIR"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Chair"))
+        ("BUILDDECALVIS3"
+         .
+         #s(item$
+            Decal
+            "BUILDDECAL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Decal"))
+        ("PROTECT"
+         .
+         #s(item$
+            Hazard-Protection
+            "PROTECT"
+            1
+            (Technology:Suit TechnologyRarity:Always TechShopRarity:Impossible)
+            "Hazard Protection"))
+        ("WAR_CURIO2"
+         .
+         #s(item$
+            |Vy'keen-Dagger|
+            "WAR_CURIO2"
+            11688
+            (Substance:Exotic Rarity:Common Product:Curiousity)
+            "Vy'keen Dagger"))
+        ("EX_YELLOW"
+         .
+         #s(item$
+            Activated-Copper
+            "EX_YELLOW"
+            245
+            (Rarity:Common)
+            "Activated Copper"))
+        ("T_RAD"
+         .
+         #s(item$
+            Upgrade-Module
+            "T_SHIPJUMP"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Upgrade Module"))
+        ("T_UNW"
+         .
+         #s(item$
+            Upgrade-Module
+            "T_SHIPJUMP"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Upgrade Module"))
+        ("JELLY"
+         .
+         #s(item$
+            Di=hydrogen-Jelly
+            "JELLY"
+            200
+            (Substance:Fuel Rarity:Common Product:Component)
+            "Di-hydrogen Jelly"))
+        ("BUILDWORKTOP"
+         .
+         #s(item$
+            Worktop
+            "BUILDWORKTOP"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Worktop"))
+        ("F_HYPERDRIVE"
+         .
+         #s(item$
+            Freighter-Hyperdrive
+            "F_HYPERDRIVE"
+            1
+            (Technology:Freighter
+             TechnologyRarity:Always
+             TechShopRarity:Impossible)
+            "Freighter Hyperdrive"))
+        ("U_SHIPMINI2"
+         .
+         #s(item$
+            |Infra=Knife-Module-(B)|
+            "U_SHIPMINI2"
+            140
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Infra-Knife Module (B)"))
+        ("T_SHOTGUN"
+         .
+         #s(item$
+            Upgrade-Module
+            "T_SHIPJUMP"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Upgrade Module"))
+        ("MEGAPROD2"
+         .
+         #s(item$
+            Quantum-Processor
+            "MEGAPROD2"
+            4400000
+            (Substance:Special Rarity:Rare Product:Tradeable)
+            "Quantum Processor"))
+        ("SCAN1"
+         .
+         #s(item$
+            Scanner
+            "SCAN1"
+            1
+            (Technology:Weapon
+             TechnologyRarity:Always
+             TechShopRarity:Impossible)
+            "Scanner"))
+        ("M_ROOF_M"
+         .
+         #s(item$
+            Metal-Roof-Panel
+            "M_ROOF_M"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Metal Roof Panel"))
+        ("OXYPROD3"
+         .
+         #s(item$
+            Superoxide-Crystal
+            "OXYPROD3"
+            5100
+            (Substance:Exotic Rarity:Rare Product:Curiousity)
+            "Superoxide Crystal"))
+        ("CARBON_SEAL"
+         .
+         #s(item$
+            Hermetic-Seal
+            "CARBON_SEAL"
+            800
+            (Substance:Catalyst Rarity:Uncommon Product:Component)
+            "Hermetic Seal"))
+        ("TRA_COMMODITY4"
+         .
+         #s(item$
+            TRA_COMMODITY4
+            "TRA_COMMODITY4"
+            30000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "TRA_COMMODITY4"))
+        ("BUILDLIGHT2"
+         .
+         #s(item$
+            Light
+            "SMALLLIGHT"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Light"))
+        ("SACVENOMPLANT"
+         .
+         #s(item$
+            Venom-Urchin
+            "SACVENOMPLANT"
+            3
+            (Substance:BuildingPart Rarity:Rare Product:BuildingPart)
+            "Venom Urchin"))
+        ("MAINT_PORTAL9"
+         .
+         #s(item$
+            Portal-Glyph
+            "MAINT_PORTAL1"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Portal Glyph"))
+        ("MAINT_FRIG4"
+         .
+         #s(item$
+            Servo-Arm
+            "MAINT_TECH15"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Servo Arm"))
+        ("STELLAR2"
+         .
+         #s(item$
+            Chromatic-Metal
+            "STELLAR2"
+            245
+            (Rarity:Rare)
+            "Chromatic Metal"))
+        ("W_DOORWINDOW"
+         .
+         #s(item$
+            Wooden-Frontage
+            "W_DOORWINDOW"
+            2
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Wooden Frontage"))
+        ("CATA_CRAFT"
+         .
+         #s(item$
+            Sodium-Diode
+            "CATA_CRAFT"
+            3500
+            (Substance:Stellar Rarity:Uncommon Product:Component)
+            "Sodium Diode"))
+        ("MEGAPROD3"
+         .
+         #s(item$
+            Cryogenic-Chamber
+            "MEGAPROD3"
+            3800000
+            (Substance:Special Rarity:Rare Product:Tradeable)
+            "Cryogenic Chamber"))
+        ("HYPERDRIVE"
+         .
+         #s(item$
+            Hyperdrive
+            "HYPERDRIVE"
+            1
+            (Technology:Ship TechnologyRarity:Always TechShopRarity:Impossible)
+            "Hyperdrive"))
+        ("ARTIFACT_KEY"
+         .
+         #s(item$
+            Ancient-Key
+            "ARTIFACT_KEY"
+            1000
+            (Substance:Special Rarity:Rare Product:Curiousity)
+            "Ancient Key"))
+        ("EXP_CURIO2"
+         .
+         #s(item$
+            Korvax-Convergence-Cube
+            "EXP_CURIO2"
+            13063
+            (Substance:Exotic Rarity:Common Product:Curiousity)
+            "Korvax Convergence Cube"))
+        ("U_EXO_SUBGUN2"
+         .
+         #s(item$
+            |Nautilon-Cannon-Module-(B)|
+            "U_EXO_SUBGUN2"
+            140
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Nautilon Cannon Module (B)"))
+        ("SPEC_DIVEHELMET"
+         .
+         #s(item$
+            Lost-Bathysphere
+            "SPEC_DIVEHELMET"
+            1000
+            (Substance:Exotic Rarity:Common Product:Consumable)
+            "Lost Bathysphere"))
+        ("REACTION3"
+         .
+         #s(item$
+            Nitrogen-Salt
+            "REACTION3"
+            50000
+            (Substance:Special Rarity:Rare Product:Tradeable)
+            "Nitrogen Salt"))
+        ("TECHPANEL"
+         .
+         #s(item$
+            Tech-Panel
+            "TECHPANEL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Tech Panel"))
+        ("ATLASSUIT"
+         .
+         #s(item$
+            Remembrance
+            "ATLASSUIT"
+            1
+            (Technology:Suit
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Remembrance"))
+        ("COMPOUND3"
+         .
+         #s(item$
+            Hot-Ice
+            "COMPOUND3"
+            320000
+            (Substance:Special Rarity:Rare Product:Tradeable)
+            "Hot Ice"))
+        ("NPCSCIENCETERM"
+         .
+         #s(item$
+            Science-Terminal
+            "NPCSCIENCETERM"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Science Terminal"))
+        ("COMPOUND6"
+         .
+         #s(item$
+            Cryo=Pump
+            "COMPOUND6"
+            1500000
+            (Substance:Special Rarity:Rare Product:Tradeable)
+            "Cryo-Pump"))
+        ("CUBESTAIRS"
+         .
+         #s(item$
+            Interior-Stairs
+            "CUBESTAIRS"
+            2
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Interior Stairs"))
+        ("BUILDSOFA2L"
+         .
+         #s(item$
+            Corner-Sofa
+            "BUILDSOFA2L"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Corner Sofa"))
+        ("TECH_COMP"
+         .
+         #s(item$
+            Technology-Module
+            "TECH_COMP"
+            50000
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Technology Module"))
+        ("TRA_EXOTICS5"
+         .
+         #s(item$
+            Neural-Duct
+            "TRA_EXOTICS5"
+            50000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "Neural Duct"))
+        ("WALLFLAG3"
+         .
+         #s(item$
+            Wall-Flag
+            "WALLFLAG1"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Wall Flag"))
+        ("T_SHIPSHLD"
+         .
+         #s(item$
+            Upgrade-Module
+            "T_SHIPJUMP"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Upgrade Module"))
+        ("U_SHOTGUN1"
+         .
+         #s(item$
+            |Scatter-Blaster-Module-(C)|
+            "U_SHOTGUN1"
+            60
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Scatter Blaster Module (C)"))
+        ("W_RAMP"
+         .
+         #s(item$
+            Wooden-Ramp
+            "W_RAMP"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Wooden Ramp"))
+        ("TRA_ENERGY4"
+         .
+         #s(item$
+            Experimental-Power-Fluid
+            "TRA_ENERGY4"
+            30000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "Experimental Power Fluid"))
+        ("ALLOY6"
+         .
+         #s(item$
+            Grantine
+            "ALLOY6"
+            25000
+            (Substance:Stellar Rarity:Rare Product:Tradeable)
+            "Grantine"))
+        ("COMPOUND4"
+         .
+         #s(item$
+            Fusion-Accelerant
+            "COMPOUND4"
+            1500000
+            (Substance:Special Rarity:Rare Product:Tradeable)
+            "Fusion Accelerant"))
+        ("SPEC_VYK_BOOTS"
+         .
+         #s(item$
+            Armoured-Boots
+            "SPEC_VYK_BOOTS"
+            1000
+            (Substance:Exotic Rarity:Common Product:CustomisationPart)
+            "Armoured Boots"))
+        ("POWERGLOVE"
+         .
+         #s(item$
+            Haz=Mat-Gauntlet
+            "POWERGLOVE"
+            1
+            (Technology:Suit TechnologyRarity:Common TechShopRarity:Common)
+            "Haz-Mat Gauntlet"))
+        ("ULTRAPROD2"
+         .
+         #s(item$
+            Stasis-Device
+            "ULTRAPROD2"
+            15600000
+            (Substance:Special Rarity:Rare Product:Tradeable)
+            "Stasis Device"))
+        ("M_ROOF_C"
+         .
+         #s(item$
+            Metal-Roof-Corner
+            "M_ROOF_C"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Metal Roof Corner"))
+        ("STATUE_ASTRO_S"
+         .
+         #s(item$
+            Silver-Astronaut-Statue
+            "STATUE_ASTRO_S"
+            400
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Silver Astronaut Statue"))
+        ("POWERCELL"
+         .
+         #s(item$
+            Ion-Battery
+            "POWERCELL"
+            200
+            (Substance:Catalyst Rarity:Uncommon Product:Consumable)
+            "Ion Battery"))
+        ("TRA_MINERALS1"
+         .
+         #s(item$
+            Dirt
+            "TRA_MINERALS1"
+            1000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "Dirt"))
+        ("BUILDDECALNUM2"
+         .
+         #s(item$
+            Decal
+            "BUILDDECAL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Decal"))
+        ("T_EXGUN"
+         .
+         #s(item$
+            Upgrade-Module
+            "T_SHIPJUMP"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Upgrade Module"))
+        ("BUILDDECALNUM7"
+         .
+         #s(item$
+            Decal
+            "BUILDDECAL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Decal"))
+        ("SPEC_VYK_ARMOUR"
+         .
+         #s(item$
+            Armoured-Shoulderpads
+            "SPEC_VYK_ARMOUR"
+            3000
+            (Substance:Exotic Rarity:Common Product:CustomisationPart)
+            "Armoured Shoulderpads"))
+        ("U_RAD1"
+         .
+         #s(item$
+            |Radiation-Protection-Module-(B)|
+            "U_RAD1"
+            140
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Radiation Protection Module (B)"))
+        ("C_DOORWINDOW"
+         .
+         #s(item$
+            Concrete-Frontage
+            "C_DOORWINDOW"
+            3
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Concrete Frontage"))
+        ("WATER_CRAFT"
+         .
+         #s(item$
+            Salt-Refractor
+            "WATER_CRAFT"
+            30500
+            (Substance:Stellar Rarity:Uncommon Product:Component)
+            "Salt Refractor"))
+        ("T_SHIPBLOB"
+         .
+         #s(item$
+            Upgrade-Module
+            "T_SHIPJUMP"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Upgrade Module"))
+        ("RAILGUN"
+         .
+         #s(item$
+            Blaze-Javelin
+            "RAILGUN"
+            1
+            (Technology:Weapon TechnologyRarity:Common TechShopRarity:Common)
+            "Blaze Javelin"))
+        ("SPHERESHAPE"
+         .
+         #s(item$
+            Sphere
+            "SPHERESHAPE"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Sphere"))
+        ("QUAD_PROD"
+         .
+         #s(item$
+            Quad-Servo
+            "QUAD_PROD"
+            20000
+            (Substance:Special Rarity:Uncommon Product:Component)
+            "Quad Servo"))
+        ("FARMPROD6"
+         .
+         #s(item$
+            Unstable-Gel
+            "FARMPROD6"
+            50000
+            (Substance:Special Rarity:Rare Product:Tradeable)
+            "Unstable Gel"))
+        ("BUILD_REFINER1"
+         .
+         #s(item$
+            Portable-Refiner
+            "BUILD_REFINER1"
+            10
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Portable Refiner"))
+        ("C_FLOOR"
+         .
+         #s(item$
+            Concrete-Floor-Panel
+            "C_FLOOR"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Concrete Floor Panel"))
+        ("SPACEGUNK2"
+         .
+         #s(item$
+            Runaway-Mould
+            "SPACEGUNK2"
+            20
+            (Rarity:Common)
+            "Runaway Mould"))
+        ("BASE_TREE02"
+         .
+         #s(item$
+            Spindle-Tree
+            "BASE_TREE02"
+            500
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Spindle Tree"))
+        ("BUILDDECAL2"
+         .
+         #s(item$
+            Decal
+            "BUILDDECAL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Decal"))
+        ("ACCESS3"
+         .
+         #s(item$
+            AtlasPass-v3
+            "ACCESS3"
+            2613
+            (Substance:Stellar Rarity:Rare Product:Curiousity)
+            "AtlasPass v3"))
+        ("BUILDFLATPANEL"
+         .
+         #s(item$
+            Flat-Panel
+            "BUILDFLATPANEL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Flat Panel"))
+        ("SHIELDSTATION"
+         .
+         #s(item$
+            Hazard-Protection-Unit
+            "SHIELDSTATION"
+            3
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Hazard Protection Unit"))
+        ("SHIPSHOTGUN"
+         .
+         #s(item$
+            Positron-Ejector
+            "SHIPSHOTGUN"
+            1
+            (Technology:Ship TechnologyRarity:Impossible TechShopRarity:Common)
+            "Positron Ejector"))
+        ("TRA_COMMODITY5"
+         .
+         #s(item$
+            TRA_COMMODITY5
+            "TRA_COMMODITY5"
+            50000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "TRA_COMMODITY5"))
+        ("VIEWSPHERE"
+         .
+         #s(item$
+            Viewing-Sphere
+            "VIEWSPHERE"
+            10
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Viewing Sphere"))
+        ("T_RAIL"
+         .
+         #s(item$
+            Upgrade-Module
+            "T_SHIPJUMP"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Upgrade Module"))
+        ("UT_JUMP"
+         .
+         #s(item$
+            Rocket-Boots
+            "UT_JUMP"
+            1
+            (Technology:Suit TechnologyRarity:Common TechShopRarity:Common)
+            "Rocket Boots"))
+        ("C_ROOF_M"
+         .
+         #s(item$
+            Concrete-Roof-Panel
+            "C_ROOF_M"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Concrete Roof Panel"))
+        ("BUILDLANDINGPAD"
+         .
+         #s(item$
+            Landing-Pad
+            "BUILDLANDINGPAD"
+            10
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Landing Pad"))
+        ("WALLSCREEN"
+         .
+         #s(item$
+            Wall-Screen
+            "WALLSCREEN"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Wall Screen"))
+        ("U_HOTPROT2"
+         .
+         #s(item$
+            |Thermal-Protection-Module-(A)|
+            "U_HOTPROT2"
+            240
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Thermal Protection Module (A)"))
+        ("BUILDTOWER"
+         .
+         #s(item$
+            Tower-Module
+            "BUILDTOWER"
+            2
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Tower Module"))
+        ("TRA_ENERGY5"
+         .
+         #s(item$
+            Fusion-Core
+            "TRA_ENERGY5"
+            50000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "Fusion Core"))
+        ("MAINT_PORTAL6"
+         .
+         #s(item$
+            Portal-Glyph
+            "MAINT_PORTAL1"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Portal Glyph"))
+        ("MAINT_PORTAL16"
+         .
+         #s(item$
+            Portal-Glyph
+            "MAINT_PORTAL1"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Portal Glyph"))
+        ("TRIDENT_KEY"
+         .
+         #s(item$
+            Trident-Key
+            "TRIDENT_KEY"
+            1000
+            (Substance:Special Rarity:Rare Product:Curiousity)
+            "Trident Key"))
+        ("MAINT_FRIG7"
+         .
+         #s(item$
+            Master-Circuit
+            "MAINT_TECH18"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Master Circuit"))
+        ("CORRIDORL"
+         .
+         #s(item$
+            L=Shaped-Corridor
+            "CORRIDORL"
+            5
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "L-Shaped Corridor"))
+        ("SHIPSLOT_DMG5"
+         .
+         #s(item$
+            Containment-Failure
+            "SHIPSLOT_DMG5"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Containment Failure"))
+        ("SPEC_DECAL01"
+         .
+         #s(item$
+            Anomaly-Decal
+            "SPEC_DECAL01"
+            400
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Anomaly Decal"))
+        ("U_EXOLAS4"
+         .
+         #s(item$
+            |Exocraft-Laser-Module-(S)|
+            "U_EXOLAS4"
+            360
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Exocraft Laser Module (S)"))
+        ("COLD1" . #s(item$ Dioxite "COLD1" 62 (Rarity:Uncommon) "Dioxite"))
+        ("CONTAINER1"
+         .
+         #s(item$
+            Storage-Container
+            "CONTAINER0"
+            5
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Storage Container"))
+        ("MAINT_TECH22"
+         .
+         #s(item$
+            Safety-Panel
+            "MAINT_TECH22"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Safety Panel"))
+        ("BUILDDECALVIS5"
+         .
+         #s(item$
+            Decal
+            "BUILDDECAL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Decal"))
+        ("BASE_ROBOTOY"
+         .
+         #s(item$
+            Robotic-Companion
+            "BASE_ROBOTOY"
+            800
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Robotic Companion"))
+        ("T_HDRIVE"
+         .
+         #s(item$
+            Upgrade-Module
+            "T_SHIPJUMP"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Upgrade Module"))
+        ("MAINT_FUEL3"
+         .
+         #s(item$
+            Power-Condenser
+            "MAINT_FUEL3"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Power Condenser"))
+        ("WATER2" . #s(item$ Chlorine "WATER2" 602 (Rarity:Rare) "Chlorine"))
+        ("U_SHIPGUN3"
+         .
+         #s(item$
+            |Photon-Cannon-Module-(A)|
+            "U_SHIPGUN3"
+            240
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Photon Cannon Module (A)"))
+        ("TRA_CURIO1"
+         .
+         #s(item$
+            Gek-Relic
+            "TRA_CURIO1"
+            23375
+            (Substance:Exotic Rarity:Rare Product:Curiousity)
+            "Gek Relic"))
+        ("LAUNCHSUB"
+         .
+         #s(item$ Di=hydrogen "LAUNCHSUB" 34 (Rarity:Common) "Di-hydrogen"))
+        ("BUILDLADDER"
+         .
+         #s(item$
+            Ladder
+            "BUILDLADDER"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Ladder"))
+        ("U_SHOTGUN4"
+         .
+         #s(item$
+            |Scatter-Blaster-Module-(S)|
+            "U_SHOTGUN4"
+            360
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Scatter Blaster Module (S)"))
+        ("MAINT_TECH7"
+         .
+         #s(item$
+            Tiny-motor
+            "MAINT_TECH7"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Tiny motor"))
+        ("EXOPOD_TECH3"
+         .
+         #s(item$
+            Shattered-Power-Core
+            "EXOPOD_TECH3"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Shattered Power Core"))
+        ("U_SHIELDBOOST3"
+         .
+         #s(item$
+            |Shield-Module-(A)|
+            "U_SHIELDBOOST3"
+            240
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Shield Module (A)"))
+        ("FRIG_BOOST_COM"
+         .
+         #s(item$
+            Explosive-Drones
+            "FRIG_BOOST_COM"
+            75000
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Explosive Drones"))
+        ("SPEC_EMOTE05"
+         .
+         #s(item$
+            No-Problem
+            "SPEC_EMOTE05"
+            1500
+            (Substance:Exotic Rarity:Common Product:Emote)
+            "No Problem"))
+        ("CONTAINER5"
+         .
+         #s(item$
+            Storage-Container
+            "CONTAINER0"
+            5
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Storage Container"))
+        ("BASE_TOYCUBE"
+         .
+         #s(item$
+            Expanding-Cube-Gadget
+            "BASE_TOYCUBE"
+            800
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Expanding Cube Gadget"))
+        ("BUILDDECALVIS1"
+         .
+         #s(item$
+            Decal
+            "BUILDDECAL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Decal"))
+        ("UT_ENERGY"
+         .
+         #s(item$
+            Oxygen-Recycler
+            "UT_ENERGY"
+            1
+            (Technology:Suit TechnologyRarity:Common TechShopRarity:Common)
+            "Oxygen Recycler"))
+        ("ATLAS_SEED_1"
+         .
+         #s(item$
+            Captured-Nanode
+            "ATLAS_SEED_1"
+            1000
+            (Substance:Stellar Rarity:Rare Product:Curiousity)
+            "Captured Nanode"))
+        ("MAINT_FARM5"
+         .
+         #s(item$
+            Nutrient-Distributor
+            "MAINT_FARM5"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Nutrient Distributor"))
+        ("TRA_ALLOY3"
+         .
+         #s(item$
+            Optical-Solvent
+            "TRA_ALLOY3"
+            15000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "Optical Solvent"))
+        ("T_SHIPMINI"
+         .
+         #s(item$
+            Upgrade-Module
+            "T_SHIPJUMP"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Upgrade Module"))
+        ("U_EXOGUN2"
+         .
+         #s(item$
+            |Exocraft-Cannon-Module-(B)|
+            "U_EXOGUN2"
+            140
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Exocraft Cannon Module (B)"))
+        ("SHIPSLOT_DMG2"
+         .
+         #s(item$
+            Rusted-Circuits
+            "SHIPSLOT_DMG2"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Rusted Circuits"))
+        ("HOT1"
+         .
+         #s(item$ Phosphorus "HOT1" 62 (Rarity:Uncommon) "Phosphorus"))
+        ("CONTAINER2"
+         .
+         #s(item$
+            Storage-Container
+            "CONTAINER0"
+            5
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Storage Container"))
+        ("CUBEROOMC_SPACE"
+         .
+         #s(item$
+            Large-Freighter-Room
+            "CUBEROOM_SPACE"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Large Freighter Room"))
+        ("BASE_BARNACLE"
+         .
+         #s(item$
+            Barnacle
+            "BASE_BARNACLE"
+            500
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Barnacle"))
+        ("BUILDTABLE3"
+         .
+         #s(item$
+            Table
+            "BUILDTABLE"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Table"))
+        ("BUILDSIDEPANEL"
+         .
+         #s(item$
+            Side-Panel
+            "BUILDSIDEPANEL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Side Panel"))
+        ("PLANT_WATER"
+         .
+         #s(item$ Kelp-Sac "PLANT_WATER" 41 (Rarity:Uncommon) "Kelp Sac"))
+        ("U_TOX2"
+         .
+         #s(item$
+            |Toxic-Protection-Module-(A)|
+            "U_TOX2"
+            240
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Toxic Protection Module (A)"))
+        ("MAINT_SEALOCK2"
+         .
+         #s(item$
+            Trident-Key
+            "MAINT_SEALOCK2"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Trident Key"))
+        ("ALLOY1"
+         .
+         #s(item$
+            Aronium
+            "ALLOY1"
+            25000
+            (Substance:Stellar Rarity:Rare Product:Tradeable)
+            "Aronium"))
+        ("FARMPROD8"
+         .
+         #s(item$
+            Living-Glass
+            "FARMPROD8"
+            566000
+            (Substance:Special Rarity:Rare Product:Tradeable)
+            "Living Glass"))
+        ("T_SCAN"
+         .
+         #s(item$
+            Upgrade-Module
+            "T_SHIPJUMP"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Upgrade Module"))
+        ("WALLSCREENB2"
+         .
+         #s(item$
+            Orange-Wall-Screen
+            "WALLSCREENB2"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Orange Wall Screen"))
+        ("VEHICLE_LASER"
+         .
+         #s(item$
+            Exocraft-Mining-Laser
+            "VEHICLE_LASER"
+            1
+            (Technology:Exocraft
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Exocraft Mining Laser"))
+        ("BUILD_REFINER3"
+         .
+         #s(item$
+            Large-Refiner
+            "BUILD_REFINER3"
+            10
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Large Refiner"))
+        ("T_BOOST"
+         .
+         #s(item$
+            Upgrade-Module
+            "T_SHIPJUMP"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Upgrade Module"))
+        ("SHIPMINIGUN"
+         .
+         #s(item$
+            Infra=Knife-Accelerator
+            "SHIPMINIGUN"
+            1
+            (Technology:Ship TechnologyRarity:Impossible TechShopRarity:Normal)
+            "Infra-Knife Accelerator"))
+        ("PLANT_CAVE"
+         .
+         #s(item$ Marrow-Bulb "PLANT_CAVE" 41 (Rarity:Uncommon) "Marrow Bulb"))
+        ("M_FLOOR"
+         .
+         #s(item$
+            Metal-Floor-Panel
+            "M_FLOOR"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Metal Floor Panel"))
+        ("MEGAPROD1"
+         .
+         #s(item$
+            Portable-Reactor
+            "MEGAPROD1"
+            4200000
+            (Substance:Special Rarity:Rare Product:Tradeable)
+            "Portable Reactor"))
+        ("SPEC_DECAL07"
+         .
+         #s(item$
+            Artemis-Decal
+            "SPEC_DECAL07"
+            400
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Artemis Decal"))
+        ("GARAGE_SUB"
+         .
+         #s(item$
+            Nautilon-Chamber
+            "GARAGE_SUB"
+            10
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Nautilon Chamber"))
+        ("FRIG_BOOST_EXP"
+         .
+         #s(item$
+            Holographic-Analyser
+            "FRIG_BOOST_EXP"
+            75000
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Holographic Analyser"))
+        ("CONTAINER6"
+         .
+         #s(item$
+            Storage-Container
+            "CONTAINER0"
+            5
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Storage Container"))
+        ("BUILDPAVING"
+         .
+         #s(item$
+            Paving
+            "BUILDPAVING"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Paving"))
+        ("RADIO1" . #s(item$ Uranium "RADIO1" 62 (Rarity:Uncommon) "Uranium"))
+        ("WATERBUBBLE"
+         .
+         #s(item$
+            Marine-Shelter
+            "WATERBUBBLE"
+            10
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Marine Shelter"))
+        ("SCORCHEDPLANT"
+         .
+         #s(item$
+            Solar-Vine
+            "SCORCHEDPLANT"
+            3
+            (Substance:BuildingPart Rarity:Rare Product:BuildingPart)
+            "Solar Vine"))
+        ("SUB_ENGINE"
+         .
+         #s(item$
+            Humboldt-Drive
+            "SUB_ENGINE"
+            1
+            (Technology:Submarine
+             TechnologyRarity:Always
+             TechShopRarity:Impossible)
+            "Humboldt Drive"))
+        ("WALLLIGHTYELLOW"
+         .
+         #s(item$
+            Coloured-Light
+            "WALLLIGHTBLUE"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Coloured Light"))
+        ("TRA_EXOTICS4"
+         .
+         #s(item$
+            Organic-Piping
+            "TRA_EXOTICS4"
+            30000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "Organic Piping"))
+        ("SPACEGUNK1"
+         .
+         #s(item$
+            Residual-Goop
+            "SPACEGUNK1"
+            20
+            (Rarity:Common)
+            "Residual Goop"))
+        ("U_RAIL1"
+         .
+         #s(item$
+            |Blaze-Javelin-Module-(C)|
+            "U_RAIL1"
+            60
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Blaze Javelin Module (C)"))
+        ("RADIOPLANT"
+         .
+         #s(item$
+            Gamma-Weed
+            "RADIOPLANT"
+            3
+            (Substance:BuildingPart Rarity:Rare Product:BuildingPart)
+            "Gamma Weed"))
+        ("SPEC_HELMET02"
+         .
+         #s(item$
+            Blazing-Orbit-Helmet
+            "SPEC_HELMET02"
+            3000
+            (Substance:Exotic Rarity:Common Product:CustomisationPart)
+            "Blazing Orbit Helmet"))
+        ("MAINT_FRIG10"
+         .
+         #s(item$
+            Transmission-Box
+            "MAINT_TECH25"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Transmission Box"))
+        ("MAINT_TECH17"
+         .
+         #s(item$
+            Pressure-Chamber
+            "MAINT_TECH17"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Pressure Chamber"))
+        ("BUILDDECALNUM5"
+         .
+         #s(item$
+            Decal
+            "BUILDDECAL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Decal"))
+        ("ATLAS_STONE"
+         .
+         #s(item$
+            Atlas-Stone
+            "ATLAS_STONE"
+            68750
+            (Substance:Special Rarity:Rare Product:Curiousity)
+            "Atlas Stone"))
+        ("T_SHIPSHOT"
+         .
+         #s(item$
+            Upgrade-Module
+            "T_SHIPJUMP"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Upgrade Module"))
+        ("U_SMG3"
+         .
+         #s(item$
+            |Pulse-Spitter-Module-(A)|
+            "U_SMG3"
+            240
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Pulse Spitter Module (A)"))
+        ("F_HDRIVEBOOST2"
+         .
+         #s(item$
+            Freighter-Warp-Reactor-Tau
+            "F_HDRIVEBOOST2"
+            1
+            (Technology:Freighter
+             TechnologyRarity:Impossible
+             TechShopRarity:Rare)
+            "Freighter Warp Reactor Tau"))
+        ("FUELPROD3"
+         .
+         #s(item$
+            Carbon-Crystal
+            "FUELPROD3"
+            3600
+            (Substance:Exotic Rarity:Rare Product:Curiousity)
+            "Carbon Crystal"))
+        ("U_TGRENADE1"
+         .
+         #s(item$
+            |Geology-Cannon-Module-(C)|
+            "U_TGRENADE1"
+            60
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Geology Cannon Module (C)"))
+        ("F_HACCESS2"
+         .
+         #s(item$
+            Warp-Shielding-Tau
+            "F_HACCESS2"
+            1
+            (Technology:Freighter
+             TechnologyRarity:Impossible
+             TechShopRarity:Rare)
+            "Warp Shielding Tau"))
+        ("MAINT_TECH13"
+         .
+         #s(item$
+            Thermoregulator
+            "MAINT_TECH13"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Thermoregulator"))
+        ("U_RAD2"
+         .
+         #s(item$
+            |Radiation-Protection-Module-(A)|
+            "U_RAD2"
+            240
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Radiation Protection Module (A)"))
+        ("S_CONTAINER7"
+         .
+         #s(item$
+            Freighter-Storage-Unit
+            "S_CONTAINER0"
+            5
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Freighter Storage Unit"))
+        ("TRA_ENERGY2"
+         .
+         #s(item$
+            Industrial=Grade-Battery
+            "TRA_ENERGY2"
+            6000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "Industrial-Grade Battery"))
+        ("ATLAS_SEED_3"
+         .
+         #s(item$
+            Noospheric-Orb
+            "ATLAS_SEED_3"
+            1000
+            (Substance:Stellar Rarity:Rare Product:Curiousity)
+            "Noospheric Orb"))
+        ("FLOORMAT1"
+         .
+         #s(item$
+            Floor-Mat
+            "FLOORMAT1"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Floor Mat"))
+        ("SUB_RECHARGE"
+         .
+         #s(item$
+            Osmotic-Generator
+            "SUB_RECHARGE"
+            1
+            (Technology:Submarine
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Osmotic Generator"))
+        ("SPEC_VYK_TORSO"
+         .
+         #s(item$
+            Armoured-Chestpiece
+            "SPEC_VYK_TORSO"
+            750
+            (Substance:Exotic Rarity:Common Product:CustomisationPart)
+            "Armoured Chestpiece"))
+        ("W_ARCH_H"
+         .
+         #s(item$
+            Wooden-Half-Arch
+            "W_ARCH_H"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Wooden Half Arch"))
+        ("BASECAPSULE"
+         .
+         #s(item$
+            Base-Salvage-Capsule
+            "BASECAPSULE"
+            10
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Base Salvage Capsule"))
+        ("CAVECUBE"
+         .
+         #s(item$
+            Vortex-Cube
+            "CAVECUBE"
+            5800
+            (Substance:Exotic Rarity:Rare Product:Tradeable)
+            "Vortex Cube"))
+        ("U_EXO_ENG1"
+         .
+         #s(item$
+            |Exocraft-Engine-Module-(C)|
+            "U_EXO_ENG1"
+            60
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Exocraft Engine Module (C)"))
+        ("NPCVEHICLETERM"
+         .
+         #s(item$
+            Exocraft-Terminal
+            "NPCVEHICLETERM"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Exocraft Terminal"))
+        ("U_EXO_SUB2"
+         .
+         #s(item$
+            |Humboldt-Drive-Module-(B)|
+            "U_EXO_SUB2"
+            140
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Humboldt Drive Module (B)"))
+        ("U_JETBOOST1"
+         .
+         #s(item$
+            |Movement-Module-(C)|
+            "U_JETBOOST1"
+            60
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Movement Module (C)"))
+        ("SACVENOM"
+         .
+         #s(item$
+            Sac-Venom
+            "SACVENOM"
+            12300
+            (Substance:Exotic Rarity:Rare Product:Tradeable)
+            "Sac Venom"))
+        ("CLAMPEARL"
+         .
+         #s(item$
+            Living-Pearl
+            "CLAMPEARL"
+            5050
+            (Substance:Exotic Rarity:Rare Product:Tradeable)
+            "Living Pearl"))
+        ("BUILDDECALNUM8"
+         .
+         #s(item$
+            Decal
+            "BUILDDECAL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Decal"))
+        ("NAV_DATA_DROP"
+         .
+         #s(item$
+            Drop-Pod-Coordinate-Data
+            "NAV_DATA_DROP"
+            85000
+            (Substance:Special Rarity:Rare Product:Curiousity)
+            "Drop Pod Coordinate Data"))
+        ("BUILDGASHARVEST"
+         .
+         #s(item$
+            Atmosphere-Harvester
+            "BUILDGASHARVEST"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Atmosphere Harvester"))
+        ("UT_SMG"
+         .
+         #s(item$
+            Amplified-Cartridges
+            "UT_SMG"
+            1
+            (Technology:Weapon TechnologyRarity:Common TechShopRarity:Common)
+            "Amplified Cartridges"))
+        ("WALLFLAG2"
+         .
+         #s(item$
+            Wall-Flag
+            "WALLFLAG1"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Wall Flag"))
+        ("SPEC_VYK_LEGS"
+         .
+         #s(item$
+            Armoured-Leggings
+            "SPEC_VYK_LEGS"
+            750
+            (Substance:Exotic Rarity:Common Product:CustomisationPart)
+            "Armoured Leggings"))
+        ("ATLAS_SEED_5"
+         .
+         #s(item$
+            |Dawn's-End|
+            "ATLAS_SEED_5"
+            1000
+            (Substance:Stellar Rarity:Rare Product:Curiousity)
+            "Dawn's End"))
+        ("PLANTPOT"
+         .
+         #s(item$
+            Potted-Plant
+            "PLANTPOT"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Potted Plant"))
+        ("BUILDDECALSIMP2"
+         .
+         #s(item$
+            Decal
+            "BUILDDECAL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Decal"))
+        ("MAINT_PORTAL10"
+         .
+         #s(item$
+            Portal-Glyph
+            "MAINT_PORTAL1"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Portal Glyph"))
+        ("UT_SHIPMINI"
+         .
+         #s(item$
+            Nonlinear-Optics
+            "UT_SHIPGUN"
+            1
+            (Technology:Ship TechnologyRarity:Rare TechShopRarity:Common)
+            "Nonlinear Optics"))
+        ("BUILDDECALVIS2"
+         .
+         #s(item$
+            Decal
+            "BUILDDECAL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Decal"))
+        ("WALLLIGHTGREEN"
+         .
+         #s(item$
+            Coloured-Light
+            "WALLLIGHTBLUE"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Coloured Light"))
+        ("BLDWALLUNIT"
+         .
+         #s(item$
+            Wall-Unit
+            "BLDWALLUNIT"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Wall Unit"))
+        ("BUILDCHAIR3"
+         .
+         #s(item$
+            Chair
+            "BUILDCHAIR"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Chair"))
+        ("MAINT_TECH11"
+         .
+         #s(item$
+            Security-Alarm
+            "MAINT_TECH11"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Security Alarm"))
+        ("UT_ROCKETS"
+         .
+         #s(item$
+            Large-Rocket-Tubes
+            "UT_ROCKETS"
+            1
+            (Technology:Ship TechnologyRarity:Rare TechShopRarity:Common)
+            "Large Rocket Tubes"))
+        ("BOXEDSCREEN"
+         .
+         #s(item$
+            Oscilloscope
+            "BOXEDSCREEN"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Oscilloscope"))
+        ("UT_SCAN"
+         .
+         #s(item$
+            Waveform-Recycler
+            "UT_SCAN"
+            1
+            (Technology:Weapon TechnologyRarity:Common TechShopRarity:Common)
+            "Waveform Recycler"))
+        ("U_EXO_SUBGUN3"
+         .
+         #s(item$
+            |Nautilon-Cannon-Module-(A)|
+            "U_EXO_SUBGUN3"
+            240
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Nautilon Cannon Module (A)"))
+        ("MAINT_FRIG8"
+         .
+         #s(item$
+            Power-Distributor
+            "MAINT_TECH19"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Power Distributor"))
+        ("S_CONTAINER8"
+         .
+         #s(item$
+            Freighter-Storage-Unit
+            "S_CONTAINER0"
+            5
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Freighter Storage Unit"))
+        ("VEHICLE_LASER1"
+         .
+         #s(item$
+            Exocraft-Mining-Laser-Upgrade-Sigma
+            "VEHICLE_LASER1"
+            1
+            (Technology:Exocraft
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Exocraft Mining Laser Upgrade Sigma"))
+        ("SHIPSLOT_DMG3"
+         .
+         #s(item$
+            Shattered-Bulwark
+            "SHIPSLOT_DMG3"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Shattered Bulwark"))
+        ("PIPESHAPE"
+         .
+         #s(item$
+            Pipe
+            "PIPESHAPE"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Pipe"))
+        ("S_CONTAINER6"
+         .
+         #s(item$
+            Freighter-Storage-Unit
+            "S_CONTAINER0"
+            5
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Freighter Storage Unit"))
+        ("BASE_FLAG"
+         .
+         #s(item$
+            Base-Computer
+            "BASE_FLAG"
+            5
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Base Computer"))
+        ("CORRIDORX"
+         .
+         #s(item$
+            X=Shaped-Corridor
+            "CORRIDORX"
+            5
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "X-Shaped Corridor"))
+        ("U_LASER1"
+         .
+         #s(item$
+            |Mining-Beam-Module-(C)|
+            "U_LASER1"
+            60
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Mining Beam Module (C)"))
+        ("VEHICLE_SCAN1"
+         .
+         #s(item$
+            Exocraft-Signal-Booster-Upgrade-Sigma
+            "VEHICLE_SCAN1"
+            1
+            (Technology:Exocraft
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Exocraft Signal Booster Upgrade Sigma"))
+        ("FARMPROD7"
+         .
+         #s(item$
+            Liquid-Explosive
+            "FARMPROD7"
+            800500
+            (Substance:Special Rarity:Rare Product:Tradeable)
+            "Liquid Explosive"))
+        ("OXYGEN" . #s(item$ Oxygen "OXYGEN" 34 (Rarity:Common) "Oxygen"))
+        ("BOLT"
+         .
+         #s(item$
+            Boltcaster
+            "BOLT"
+            1
+            (Technology:Weapon
+             TechnologyRarity:VeryCommon
+             TechShopRarity:Impossible)
+            "Boltcaster"))
+        ("BUILDSIMPLEDESK"
+         .
+         #s(item$
+            Simple-Desk
+            "BUILDSIMPLEDESK"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Simple Desk"))
+        ("SPEC_EMOTE01"
+         .
+         #s(item$
+            Mind-Blown
+            "SPEC_EMOTE01"
+            1500
+            (Substance:Exotic Rarity:Common Product:Emote)
+            "Mind Blown"))
+        ("PANEL_GLASS"
+         .
+         #s(item$
+            Large-Glass-Panel
+            "PANEL_GLASS"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Large Glass Panel"))
+        ("C_WALL_WINDOW"
+         .
+         #s(item$
+            Concrete-Window-Panel
+            "C_WALL_WINDOW"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Concrete Window Panel"))
+        ("HEXCORE"
+         .
+         #s(item$
+            Hex-Core
+            "HEXCORE"
+            16
+            (Substance:Special Rarity:Rare Product:Curiousity)
+            "Hex Core"))
+        ("STATUE_BLOB_S"
+         .
+         #s(item$
+            Silver-Blob-Statue
+            "STATUE_BLOB_S"
+            400
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Silver Blob Statue"))
+        ("TRA_COMPONENT1"
+         .
+         #s(item$
+            TRA_COMPONENT1
+            "TRA_COMPONENT1"
+            1000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "TRA_COMPONENT1"))
+        ("BUILDLIGHT"
+         .
+         #s(item$
+            Light
+            "SMALLLIGHT"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Light"))
+        ("M_RAMP"
+         .
+         #s(item$
+            Metal-Ramp
+            "M_RAMP"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Metal Ramp"))
+        ("WEDGESHAPE"
+         .
+         #s(item$
+            Large-Wedge
+            "WEDGESHAPE"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Large Wedge"))
+        ("GAS2" . #s(item$ Radon "GAS2" 20 (Rarity:Uncommon) "Radon"))
+        ("PLANTPOT2"
+         .
+         #s(item$
+            Flora-Containment
+            "PLANTPOT1"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Flora Containment"))
+        ("TRA_COMPONENT2"
+         .
+         #s(item$
+            TRA_COMPONENT2
+            "TRA_COMPONENT2"
+            6000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "TRA_COMPONENT2"))
+        ("BASE_WPLANT2"
+         .
+         #s(item$
+            Aquatic-Crystal
+            "BASE_WPLANT2"
+            500
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Aquatic Crystal"))
+        ("MAINT_FRIG3"
+         .
+         #s(item$
+            Thermoregulator
+            "MAINT_TECH13"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Thermoregulator"))
+        ("ATLAS_SEED_2"
+         .
+         #s(item$
+            Englobed-Shade
+            "ATLAS_SEED_2"
+            1000
+            (Substance:Stellar Rarity:Rare Product:Curiousity)
+            "Englobed Shade"))
+        ("T_SUB"
+         .
+         #s(item$
+            Upgrade-Module
+            "T_SHIPJUMP"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Upgrade Module"))
+        ("BUILDDECALNUM6"
+         .
+         #s(item$
+            Decal
+            "BUILDDECAL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Decal"))
+        ("CUBEWINDOWSMALL"
+         .
+         #s(item$
+            Window
+            "BUILDWINDOW"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Window"))
+        ("U_EXOLAS1"
+         .
+         #s(item$
+            |Exocraft-Laser-Module-(C)|
+            "U_EXOLAS1"
+            60
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Exocraft Laser Module (C)"))
+        ("M_WALL_WINDOW"
+         .
+         #s(item$
+            Metal-Window-Panel
+            "M_WALL_WINDOW"
+            2
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Metal Window Panel"))
+        ("STATUE_DIP_G"
+         .
+         #s(item$
+            Gold-Diplo-Statue
+            "STATUE_DIP_G"
+            500
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Gold Diplo Statue"))
+        ("FRIGATE_FUEL_3"
+         .
+         #s(item$
+            |Frigate-Fuel-(200-Tonnes)|
+            "FRIGATE_FUEL_3"
+            80000
+            (Substance:Fuel Rarity:Rare Product:Consumable)
+            "Frigate Fuel (200 Tonnes)"))
+        ("U_GRENADE2"
+         .
+         #s(item$
+            |Plasma-Launcher-Module-(B)|
+            "U_GRENADE2"
+            140
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Plasma Launcher Module (B)"))
+        ("M_DOOR"
+         .
+         #s(item$
+            Metal-Door-Frame
+            "M_DOOR"
+            2
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Metal Door Frame"))
+        ("W_WALL"
+         .
+         #s(item$
+            Wooden-Wall
+            "W_WALL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Wooden Wall"))
+        ("GAS3" . #s(item$ Nitrogen "GAS3" 20 (Rarity:Rare) "Nitrogen"))
+        ("CUBESOLID"
+         .
+         #s(item$
+            Solid-Cube
+            "CUBESOLID"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Solid Cube"))
+        ("TRA_MINERALS4"
+         .
+         #s(item$
+            Polychromatic-Zirconium
+            "TRA_MINERALS4"
+            30000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "Polychromatic Zirconium"))
+        ("STATUE_SHIP_S"
+         .
+         #s(item$
+            Silver-Fighter-Statue
+            "STATUE_SHIP_S"
+            400
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Silver Fighter Statue"))
+        ("LUSHPLANT"
+         .
+         #s(item$
+            Star-Bramble
+            "LUSHPLANT"
+            3
+            (Substance:BuildingPart Rarity:Rare Product:BuildingPart)
+            "Star Bramble"))
+        ("U_UNW1"
+         .
+         #s(item$
+            |Underwater-Protection-Module-(B)|
+            "U_UNW1"
+            140
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Underwater Protection Module (B)"))
+        ("SHIPSUMMON"
+         .
+         #s(item$
+            Muster-Point
+            "SHIPSUMMON"
+            10
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Muster Point"))
+        ("MAINT_TECH16"
+         .
+         #s(item$
+            Solenoid
+            "MAINT_TECH16"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Solenoid"))
+        ("CRATELRARE"
+         .
+         #s(item$
+            Crate-Fabricator
+            "CRATELRARE"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Crate Fabricator"))
+        ("BUILDAMCRATE"
+         .
+         #s(item$
+            Small-Crate
+            "BUILDAMCRATE"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Small Crate"))
+        ("PLANT_RADIO"
+         .
+         #s(item$ Gamma-Root "PLANT_RADIO" 16 (Rarity:Rare) "Gamma Root"))
+        ("SPEC_DECAL06"
+         .
+         #s(item$
+            Apollo-Decal
+            "SPEC_DECAL06"
+            400
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Apollo Decal"))
+        ("CAVE_CRAFT"
+         .
+         #s(item$
+            Cobalt-Mirror
+            "CAVE_CRAFT"
+            20500
+            (Substance:Stellar Rarity:Uncommon Product:Component)
+            "Cobalt Mirror"))
+        ("BASE_AQUARIUM"
+         .
+         #s(item$
+            Small-Aquarium
+            "BASE_AQUARIUM"
+            800
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Small Aquarium"))
+        ("M_WALLDIAGONAL"
+         .
+         #s(item$
+            Sloping-Metal-Panel
+            "M_WALLDIAGONAL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Sloping Metal Panel"))
+        ("GROUND_SHIELD"
+         .
+         #s(item$
+            Personal-Forcefield
+            "GROUND_SHIELD"
+            1
+            (Technology:Weapon TechnologyRarity:Common TechShopRarity:Common)
+            "Personal Forcefield"))
+        ("WEAPSLOT_DMG6"
+         .
+         #s(item$
+            Loom-Damage
+            "WEAPSLOT_DMG6"
+            1
+            (Technology:Weapon
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Loom Damage"))
+        ("BUILDSOFA"
+         .
+         #s(item$
+            Sofa
+            "BUILDSOFA"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Sofa"))
+        ("AM_HOUSING"
+         .
+         #s(item$
+            Antimatter-Housing
+            "AM_HOUSING"
+            6500
+            (Substance:Special Rarity:Uncommon Product:Component)
+            "Antimatter Housing"))
+        ("CURVEDDESK"
+         .
+         #s(item$
+            Curved-Desk
+            "CURVEDDESK"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Curved Desk"))
+        ("U_BOLT1"
+         .
+         #s(item$
+            |Boltcaster-Module-(C)|
+            "U_BOLT1"
+            60
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Boltcaster Module (C)"))
+        ("UT_SHIPSHIELD"
+         .
+         #s(item$
+            Ablative-Armour
+            "UT_SHIPSHIELD"
+            1
+            (Technology:Ship TechnologyRarity:Rare TechShopRarity:Common)
+            "Ablative Armour"))
+        ("TECHFRAG"
+         .
+         #s(item$ Nanite-Cluster "TECHFRAG" 20 (Rarity:Rare) "Nanite Cluster"))
+        ("TRA_COMMODITY3"
+         .
+         #s(item$
+            TRA_COMMODITY3
+            "TRA_COMMODITY3"
+            15000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "TRA_COMMODITY3"))
+        ("TRA_EXOTICS3"
+         .
+         #s(item$
+            Instability-Injector
+            "TRA_EXOTICS3"
+            15000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "Instability Injector"))
+        ("U_SCANNER3"
+         .
+         #s(item$
+            |Scanner-Module-(A)|
+            "U_SCANNER3"
+            240
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Scanner Module (A)"))
+        ("SPEC_EMOTE03"
+         .
+         #s(item$
+            Ha!
+            "SPEC_EMOTE03"
+            1500
+            (Substance:Exotic Rarity:Common Product:Emote)
+            "Ha!"))
+        ("BUILDTABLE"
+         .
+         #s(item$
+            Table
+            "BUILDTABLE"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Table"))
+        ("U_TOX3"
+         .
+         #s(item$
+            |Toxic-Protection-Module-(S)|
+            "U_TOX3"
+            360
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Toxic Protection Module (S)"))
+        ("CORRIDORL_SPACE"
+         .
+         #s(item$
+            Curved-Freighter-Corridor
+            "CORRIDORL_SPACE"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Curved Freighter Corridor"))
+        ("MAINT_FUEL4"
+         .
+         #s(item$
+            Generator-Coupling
+            "MAINT_FUEL4"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Generator Coupling"))
+        ("U_SHIPMINI4"
+         .
+         #s(item$
+            |Infra=Knife-Module-(S)|
+            "U_SHIPMINI4"
+            360
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Infra-Knife Module (S)"))
+        ("T_EXENG"
+         .
+         #s(item$
+            Upgrade-Module
+            "T_SHIPJUMP"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Upgrade Module"))
+        ("MAINT_TECH19"
+         .
+         #s(item$
+            Power-Distributor
+            "MAINT_TECH19"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Power Distributor"))
+        ("FLAG1"
+         .
+         #s(item$
+            Flag
+            "FLAG1"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Flag"))
+        ("BASE_MEDPLANT01"
+         .
+         #s(item$
+            Carnivorous-Bush
+            "BASE_MEDPLANT01"
+            500
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Carnivorous Bush"))
+        ("NPCFRIGTERM"
+         .
+         #s(item$
+            Fleet-Command-Room
+            "NPCFRIGTERM"
+            10
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Fleet Command Room"))
+        ("BASE_WPLANT3"
+         .
+         #s(item$
+            Candelabra-Bloom
+            "BASE_WPLANT3"
+            500
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Candelabra Bloom"))
+        ("TRA_ALLOY2"
+         .
+         #s(item$
+            Self=Repairing-Heridium
+            "TRA_ALLOY2"
+            6000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "Self-Repairing Heridium"))
+        ("CUBEFOUND"
+         .
+         #s(item$
+            Cuboid-Room-Foundation-Strut
+            "CUBEFOUND"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Cuboid Room Foundation Strut"))
+        ("MAINT_TECH25"
+         .
+         #s(item$
+            Transmission-Box
+            "MAINT_TECH25"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Transmission Box"))
+        ("STATUE_SHIP_G"
+         .
+         #s(item$
+            Gold-Fighter-Statue
+            "STATUE_SHIP_G"
+            500
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Gold Fighter Statue"))
+        ("CORNERPOST"
+         .
+         #s(item$
+            Linking-Post
+            "CORNERPOST"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Linking Post"))
+        ("U_HYPER4"
+         .
+         #s(item$
+            |Hyperdrive-Module-(S)|
+            "U_HYPER4"
+            360
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Hyperdrive Module (S)"))
+        ("BUILDLIGHTTABLE"
+         .
+         #s(item$
+            Light-Table
+            "BUILDLIGHTTABLE"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Light Table"))
+        ("JET1"
+         .
+         #s(item$
+            Jetpack
+            "JET1"
+            1
+            (Technology:Suit TechnologyRarity:Always TechShopRarity:Impossible)
+            "Jetpack"))
+        ("MESSAGEMODULE"
+         .
+         #s(item$
+            Message-Module
+            "MESSAGEMODULE"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Message Module"))
+        ("T_SHIPGUN"
+         .
+         #s(item$
+            Upgrade-Module
+            "T_SHIPJUMP"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Upgrade Module"))
+        ("FRIGATE_FUEL_1"
+         .
+         #s(item$
+            |Frigate-Fuel-(50-Tonnes)|
+            "FRIGATE_FUEL_1"
+            20000
+            (Substance:Fuel Rarity:Rare Product:Consumable)
+            "Frigate Fuel (50 Tonnes)"))
+        ("CAVE2"
+         .
+         #s(item$ Ionised-Cobalt "CAVE2" 401 (Rarity:Rare) "Ionised Cobalt"))
+        ("CORRIDORX_SPACE"
+         .
+         #s(item$
+            Freighter-Cross-Junction
+            "CORRIDORX_SPACE"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Freighter Cross Junction"))
+        ("U_SMG4"
+         .
+         #s(item$
+            |Pulse-Spitter-Module-(S)|
+            "U_SMG4"
+            360
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Pulse Spitter Module (S)"))
+        ("W_ROOF_M"
+         .
+         #s(item$
+            Wooden-Roof-Panel
+            "W_ROOF_M"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Wooden Roof Panel"))
+        ("W_WALL_WINDOW"
+         .
+         #s(item$
+            Wooden-Window-Panel
+            "W_WALL_WINDOW"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Wooden Window Panel"))
+        ("ROOFMONITOR"
+         .
+         #s(item$
+            Ceiling-Panel
+            "ROOFMONITOR"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Ceiling Panel"))
+        ("TRA_EXOTICS2"
+         .
+         #s(item$
+            Neutron-Microscope
+            "TRA_EXOTICS2"
+            6000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "Neutron Microscope"))
+        ("BUILDWINDOW"
+         .
+         #s(item$
+            Window
+            "BUILDWINDOW"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Window"))
+        ("FRIG_BOOST_TRA"
+         .
+         #s(item$
+            Mind-Control-Device
+            "FRIG_BOOST_TRA"
+            75000
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Mind Control Device"))
+        ("T_SHIPLAS"
+         .
+         #s(item$
+            Upgrade-Module
+            "T_SHIPJUMP"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Upgrade Module"))
+        ("SUB_GUN"
+         .
+         #s(item$
+            Nautilon-Cannon
+            "SUB_GUN"
+            1
+            (Technology:Submarine
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Nautilon Cannon"))
+        ("UT_JET"
+         .
+         #s(item$
+            Neural-Stimulator
+            "UT_JET"
+            1
+            (Technology:Suit TechnologyRarity:Common TechShopRarity:Common)
+            "Neural Stimulator"))
+        ("BASE_MEDPLANT03"
+         .
+         #s(item$
+            Curious-Corn
+            "BASE_MEDPLANT03"
+            500
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Curious Corn"))
+        ("BUILDSIGNAL"
+         .
+         #s(item$
+            Signal-Booster
+            "BUILDSIGNAL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Signal Booster"))
+        ("T_ENERGY"
+         .
+         #s(item$
+            Upgrade-Module
+            "T_SHIPJUMP"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Upgrade Module"))
+        ("F_HDRIVEBOOST1"
+         .
+         #s(item$
+            Freighter-Warp-Reactor-Sigma
+            "F_HDRIVEBOOST1"
+            1
+            (Technology:Freighter
+             TechnologyRarity:Impossible
+             TechShopRarity:Normal)
+            "Freighter Warp Reactor Sigma"))
+        ("CONTAINER9"
+         .
+         #s(item$
+            Storage-Container
+            "CONTAINER0"
+            5
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Storage Container"))
+        ("PLANT_TOXIC"
+         .
+         #s(item$ Fungal-Mould "PLANT_TOXIC" 16 (Rarity:Rare) "Fungal Mould"))
+        ("WALLLIGHTBLUE"
+         .
+         #s(item$
+            Coloured-Light
+            "WALLLIGHTBLUE"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Coloured Light"))
+        ("VEHICLE_SCAN"
+         .
+         #s(item$
+            Exocraft-Signal-Booster
+            "VEHICLE_SCAN"
+            1
+            (Technology:Exocraft
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Exocraft Signal Booster"))
+        ("W_WALL_Q_H"
+         .
+         #s(item$
+            Short-Wooden-Wall
+            "W_WALL_Q_H"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Short Wooden Wall"))
+        ("FRIGATE_FUEL_2"
+         .
+         #s(item$
+            |Frigate-Fuel-(100-Tonnes)|
+            "FRIGATE_FUEL_2"
+            40000
+            (Substance:Fuel Rarity:Rare Product:Consumable)
+            "Frigate Fuel (100 Tonnes)"))
+        ("MAINT_TECH3"
+         .
+         #s(item$
+            Superconductive-Lock
+            "MAINT_TECH3"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Superconductive Lock"))
+        ("BUILDTABLE2"
+         .
+         #s(item$
+            Table
+            "BUILDTABLE"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Table"))
+        ("EX_GREEN"
+         .
+         #s(item$
+            Activated-Emeril
+            "EX_GREEN"
+            696
+            (Rarity:Rare)
+            "Activated Emeril"))
+        ("U_SHIPLAS3"
+         .
+         #s(item$
+            |Phase-Beam-Module-(A)|
+            "U_SHIPLAS3"
+            240
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Phase Beam Module (A)"))
+        ("CORSTAIRS_SPACE"
+         .
+         #s(item$
+            Freighter-Stairs
+            "CORSTAIRS_SPACE"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Freighter Stairs"))
+        ("NPCFARMTERM"
+         .
+         #s(item$
+            Agricultural-Terminal
+            "NPCFARMTERM"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Agricultural Terminal"))
+        ("CORRIDORT_WATER"
+         .
+         #s(item$
+            T=Shaped-Glass-Tunnel
+            "CORRIDORT_WATER"
+            3
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "T-Shaped Glass Tunnel"))
+        ("SPEC_DECAL05"
+         .
+         #s(item$
+            Polo-Decal
+            "SPEC_DECAL05"
+            400
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Polo Decal"))
+        ("TRA_MINERALS3"
+         .
+         #s(item$
+            Bromide-Salt
+            "TRA_MINERALS3"
+            15000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "Bromide Salt"))
+        ("ALLOY2"
+         .
+         #s(item$
+            Dirty-Bronze
+            "ALLOY2"
+            25000
+            (Substance:Stellar Rarity:Rare Product:Tradeable)
+            "Dirty Bronze"))
+        ("M_FLOOR_Q"
+         .
+         #s(item$
+            Small-Metal-Panel
+            "M_FLOOR_Q"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Small Metal Panel"))
+        ("M_ARCH_H"
+         .
+         #s(item$
+            Metal-Half-Arch
+            "M_ARCH_H"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Metal Half Arch"))
+        ("POWERCELL2"
+         .
+         #s(item$
+            Advanced-Ion-Battery
+            "POWERCELL2"
+            500
+            (Substance:Catalyst Rarity:Uncommon Product:Consumable)
+            "Advanced Ion Battery"))
+        ("S_CONTAINER3"
+         .
+         #s(item$
+            Freighter-Storage-Unit
+            "S_CONTAINER0"
+            5
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Freighter Storage Unit"))
+        ("GRENADE"
+         .
+         #s(item$
+            Plasma-Launcher
+            "GRENADE"
+            1
+            (Technology:Weapon TechnologyRarity:Common TechShopRarity:Common)
+            "Plasma Launcher"))
+        ("GRAVBALL"
+         .
+         #s(item$
+            Gravitino-Ball
+            "GRAVBALL"
+            13100
+            (Substance:Exotic Rarity:Rare Product:Tradeable)
+            "Gravitino Ball"))
+        ("ATLAS_SEED_6"
+         .
+         #s(item$
+            Photic-Jade
+            "ATLAS_SEED_6"
+            1000
+            (Substance:Stellar Rarity:Rare Product:Curiousity)
+            "Photic Jade"))
+        ("VEHICLE_SCAN2"
+         .
+         #s(item$
+            Exocraft-Signal-Booster-Upgrade-Tau
+            "VEHICLE_SCAN2"
+            1
+            (Technology:Exocraft
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Exocraft Signal Booster Upgrade Tau"))
+        ("STATUE_WALK_G"
+         .
+         #s(item$
+            Gold-Walker-Statue
+            "STATUE_WALK_G"
+            500
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Gold Walker Statue"))
+        ("S_CONTAINER1"
+         .
+         #s(item$
+            Freighter-Storage-Unit
+            "S_CONTAINER0"
+            5
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Freighter Storage Unit"))
+        ("T_T_GREN"
+         .
+         #s(item$
+            Upgrade-Module
+            "T_SHIPJUMP"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Upgrade Module"))
+        ("U_RAIL4"
+         .
+         #s(item$
+            |Blaze-Javelin-Module-(S)|
+            "U_RAIL4"
+            360
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Blaze Javelin Module (S)"))
+        ("EXP_CURIO1"
+         .
+         #s(item$
+            Korvax-Casing
+            "EXP_CURIO1"
+            22000
+            (Substance:Exotic Rarity:Rare Product:Curiousity)
+            "Korvax Casing"))
+        ("ALLOY7"
+         .
+         #s(item$
+            Geodesite
+            "ALLOY7"
+            150000
+            (Substance:Stellar Rarity:Rare Product:Tradeable)
+            "Geodesite"))
+        ("WEAPSLOT_DMG4"
+         .
+         #s(item$
+            Rusted-Power-Core
+            "WEAPSLOT_DMG4"
+            1
+            (Technology:Weapon
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Rusted Power Core"))
+        ("TRA_ALLOY1"
+         .
+         #s(item$
+            Nanotube-Crate
+            "TRA_ALLOY1"
+            1000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "Nanotube Crate"))
+        ("CUBEROOMCURVED"
+         .
+         #s(item$
+            Curved-Cuboid-Wall
+            "CUBEROOMCURVED"
+            3
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Curved Cuboid Wall"))
+        ("MAINT_TECH14"
+         .
+         #s(item$
+            Fuel-Pump
+            "MAINT_TECH14"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Fuel Pump"))
+        ("WEAPSLOT_DMG1"
+         .
+         #s(item$
+            Short-Circuit
+            "WEAPSLOT_DMG1"
+            1
+            (Technology:Weapon
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Short Circuit"))
+        ("W_RAMP_H"
+         .
+         #s(item$
+            Wooden-Half-Ramp
+            "W_RAMP_H"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Wooden Half Ramp"))
+        ("T_TOX"
+         .
+         #s(item$
+            Upgrade-Module
+            "T_SHIPJUMP"
+            1
+            (Technology:Ship
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Upgrade Module"))
+        ("PLANT_SNOW"
+         .
+         #s(item$ Frost-Crystal "PLANT_SNOW" 12 (Rarity:Rare) "Frost Crystal"))
+        ("WALLCURVED"
+         .
+         #s(item$
+            Curved-Wall
+            "WALLCURVED"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Curved Wall"))
+        ("SCOPE"
+         .
+         #s(item$
+            Combat-Scope
+            "SCOPE"
+            1
+            (Technology:Weapon TechnologyRarity:Common TechShopRarity:Common)
+            "Combat Scope"))
+        ("MAINT_TECH6"
+         .
+         #s(item$
+            Boiler-Unit
+            "MAINT_TECH6"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Boiler Unit"))
+        ("MAINT_FUEL1"
+         .
+         #s(item$
+            Fuel-Inverter
+            "MAINT_FUEL1"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Fuel Inverter"))
+        ("U_SHIPSHIELD1"
+         .
+         #s(item$
+            |Starship-Shield-Module-(C)|
+            "U_SHIPSHIELD1"
+            60
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Starship Shield Module (C)"))
+        ("OXY_CRAFT"
+         .
+         #s(item$
+            Oxygen-Filter
+            "OXY_CRAFT"
+            615
+            (Substance:Stellar Rarity:Uncommon Product:Component)
+            "Oxygen Filter"))
+        ("U_SHIPSHOT3"
+         .
+         #s(item$
+            |Positron-Module-(A)|
+            "U_SHIPSHOT3"
+            240
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Positron Module (A)"))
+        ("U_SHIPBLOB1"
+         .
+         #s(item$
+            |Cyclotron-Module-(C)|
+            "U_SHIPBLOB1"
+            60
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Cyclotron Module (C)"))
+        ("FOUNDATION"
+         .
+         #s(item$
+            Foundation
+            "FOUNDATION"
+            3
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Foundation"))
+        ("UT_BOLT"
+         .
+         #s(item$
+            Barrel-Ioniser
+            "UT_BOLT"
+            1
+            (Technology:Weapon TechnologyRarity:Common TechShopRarity:Common)
+            "Barrel Ioniser"))
+        ("MAINT_FARM4"
+         .
+         #s(item$
+            Auto=Propagator
+            "MAINT_FARM4"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Auto-Propagator"))
+        ("WALL"
+         .
+         #s(item$
+            Wall
+            "WALL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Wall"))
+        ("DUSTY1" . #s(item$ Pyrite "DUSTY1" 62 (Rarity:Uncommon) "Pyrite"))
+        ("W_WALL_H"
+         .
+         #s(item$
+            Thin-Wooden-Wall
+            "W_WALL_H"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Thin Wooden Wall"))
+        ("SPEC_HELMET01"
+         .
+         #s(item$
+            Sparse-Horizon-Helmet
+            "SPEC_HELMET01"
+            3000
+            (Substance:Exotic Rarity:Common Product:CustomisationPart)
+            "Sparse Horizon Helmet"))
+        ("RED2" . #s(item$ Cadmium "RED2" 234 (Rarity:Rare) "Cadmium"))
+        ("DRAWS"
+         .
+         #s(item$
+            Drawers
+            "DRAWS"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Drawers"))
+        ("U_UNW2"
+         .
+         #s(item$
+            |Underwater-Protection-Module-(A)|
+            "U_UNW2"
+            240
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Underwater Protection Module (A)"))
+        ("CONTAINER0"
+         .
+         #s(item$
+            Storage-Container
+            "CONTAINER0"
+            5
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Storage Container"))
+        ("ASTEROID2" . #s(item$ Gold "ASTEROID2" 202 (Rarity:Uncommon) "Gold"))
+        ("TRA_COMPONENT4"
+         .
+         #s(item$
+            TRA_COMPONENT4
+            "TRA_COMPONENT4"
+            30000
+            (Substance:Exotic Rarity:Common Product:Tradeable)
+            "TRA_COMPONENT4"))
+        ("U_SHIPSHIELD2"
+         .
+         #s(item$
+            |Starship-Shield-Module-(B)|
+            "U_SHIPSHIELD2"
+            140
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Starship Shield Module (B)"))
+        ("U_EXOGUN1"
+         .
+         #s(item$
+            |Exocraft-Cannon-Module-(C)|
+            "U_EXOGUN1"
+            60
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Exocraft Cannon Module (C)"))
+        ("ROBOT1" . #s(item$ Pugneum "ROBOT1" 138 (Rarity:Rare) "Pugneum"))
+        ("M_WALL"
+         .
+         #s(item$
+            Metal-Wall
+            "M_WALL"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Metal Wall"))
+        ("BASE_TREE03"
+         .
+         #s(item$
+            Evergreen-Tree
+            "BASE_TREE03"
+            500
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Evergreen Tree"))
+        ("MAINT_PORTAL4"
+         .
+         #s(item$
+            Portal-Glyph
+            "MAINT_PORTAL1"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Portal Glyph"))
+        ("SPEC_DECAL08"
+         .
+         #s(item$
+            Null-Decal
+            "SPEC_DECAL08"
+            400
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Null Decal"))
+        ("MAINT_PORTAL12"
+         .
+         #s(item$
+            Portal-Glyph
+            "MAINT_PORTAL1"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Portal Glyph"))
+        ("LAUNCHSUB2"
+         .
+         #s(item$ Deuterium "LAUNCHSUB2" 34 (Rarity:Common) "Deuterium"))
+        ("MONITORDESK"
+         .
+         #s(item$
+            Monitor-Station
+            "MONITORDESK"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Monitor Station"))
+        ("CUBEGLASS"
+         .
+         #s(item$
+            Glass-Cuboid-Room
+            "CUBEGLASS"
+            5
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Glass Cuboid Room"))
+        ("HYPERFUEL1"
+         .
+         #s(item$
+            Warp-Cell
+            "HYPERFUEL1"
+            46750
+            (Substance:Special Rarity:Rare Product:Consumable)
+            "Warp Cell"))
+        ("BARRENPLANT"
+         .
+         #s(item$
+            Echinocactus
+            "BARRENPLANT"
+            3
+            (Substance:BuildingPart Rarity:Rare Product:BuildingPart)
+            "Echinocactus"))
+        ("C_RAMP"
+         .
+         #s(item$
+            Concrete-Ramp
+            "C_RAMP"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Concrete Ramp"))
+        ("ALBUMENPEARL"
+         .
+         #s(item$
+            Albumen-Pearl
+            "ALBUMENPEARL"
+            9500
+            (Substance:Exotic Rarity:Rare Product:Tradeable)
+            "Albumen Pearl"))
+        ("MICROCHIP"
+         .
+         #s(item$
+            Microprocessor
+            "MICROCHIP"
+            2000
+            (Substance:Catalyst Rarity:Rare Product:Component)
+            "Microprocessor"))
+        ("BP_ANALYSER"
+         .
+         #s(item$
+            Blueprint-Analyser
+            "BP_ANALYSER"
+            10
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Blueprint Analyser"))
+        ("C_ARCH_H"
+         .
+         #s(item$
+            Concrete-Half-Arch
+            "C_ARCH_H"
+            1
+            (Substance:BuildingPart Rarity:Common Product:BuildingPart)
+            "Concrete Half Arch"))
+        ("MAINT_TECH1"
+         .
+         #s(item$
+            Locking-mechanism
+            "MAINT_TECH1"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Locking mechanism"))
+        ("CREATUREPLANT"
+         .
+         #s(item$
+            Mordite-Root
+            "CREATUREPLANT"
+            3
+            (Substance:BuildingPart Rarity:Rare Product:BuildingPart)
+            "Mordite Root"))
+        ("MAINT_TECH2"
+         .
+         #s(item$
+            Magnetic-Lock
+            "MAINT_TECH2"
+            1
+            (Technology:Maintenance
+             TechnologyRarity:Impossible
+             TechShopRarity:Impossible)
+            "Magnetic Lock"))
+        ("ATLAS_SEED_8"
+         .
+         #s(item$
+            Novae-Reclaiment
+            "ATLAS_SEED_8"
+            1000
+            (Substance:Stellar Rarity:Rare Product:Curiousity)
+            "Novae Reclaiment"))))
+(for (((id item) generated-items)) (add-item id item))

--- a/generated-recipes.rkt
+++ b/generated-recipes.rkt
@@ -1,5 +1,5 @@
 #lang racket
-; Generated via parse-items.rkt by danm at 2018-11-04T20:28:51 Eastern Standard Time
+; Generated via parse-items.rkt by danm at 2018-11-07T21:27:44 Eastern Standard Time
 (require "items.rkt" "recipes.rkt")
 (define generated-build-recipes
   '((Ablative-Armour (Cobalt-Mirror . 1) (Sodium-Nitrate . 50))
@@ -37,7 +37,6 @@
      (Uranium . 100)
      (Metal-Plating . 2)
      (Advanced-Ion-Battery . 1))
-    (BRIDGECONNECTOR (Silver . 120) (Tritium . 20))
     (Barnacle (Cyto=Phosphate . 80))
     (Barrel-Fabricator (Ionised-Cobalt . 10) (Antimatter . 1))
     (Barrel-Ioniser (Cobalt-Mirror . 1) (Technology-Module . 1))
@@ -64,7 +63,6 @@
     (Bronze-Fighter-Statue (Pure-Ferrite . 15) (Copper . 15))
     (Bronze-Gek-Statue (Pure-Ferrite . 15) (Copper . 15))
     (Bronze-Walker-Statue (Pure-Ferrite . 15) (Copper . 15))
-    (CORRIDOR_WINDOW (Ionised-Cobalt . 5) (Glass . 1))
     (Cadmium-Drive (Chromatic-Metal . 250) (Technology-Module . 1))
     (Candelabra-Bloom (Cyto=Phosphate . 80))
     (Canister-Rack (Condensed-Carbon . 10))
@@ -267,7 +265,6 @@
      (Magnetised-Ferrite . 50)
      (Tritium . 50)
      (Technology-Module . 1))
-    (HEALTHPLANT (Carbon . 10))
     (Hand-of-Approval-Decal (Carbon . 20))
     (Haz=Mat-Gauntlet (Chromatic-Metal . 50) (Sodium-Nitrate . 20))
     (Hazard-Protection (Ferrite-Dust . 100))
@@ -379,7 +376,6 @@
      (Living-Pearl . 2))
     (Mordite-Root (Mordite . 40))
     (Muster-Point (Pure-Ferrite . 10))
-    (NPCEXPLORER001 (Pure-Ferrite . 50))
     (Nada-Decal (Carbon . 20))
     (Nautilon-Cannon
      (Chlorine . 100)

--- a/items.rkt
+++ b/items.rkt
@@ -61,8 +61,11 @@
 (define (get-sorted-item-names)
   (sort (hash-keys items) symbol<?))
 
-(define (add-item item)
-  (hash-set! items (item$-name item) item)
-  (hash-set! items-by-save-id (item$-id item) item))
+(define (add-item id item)
+  (define name (item$-name item))
+  (define existing-item (hash-ref items name #f))
+  (unless existing-item
+    (hash-set! items (item$-name item) item))
+  (hash-set! items-by-save-id id (or existing-item item)))
 
          


### PR DESCRIPTION
IDs for all synonymous items are now tracked and correctly recognized in save files. Internally, they map to the same item structure.
